### PR TITLE
chore: add lefthook hooks and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Asia/Kuala_Lumpur
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+      include: scope
+    groups:
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - minor
+          - patch
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Asia/Kuala_Lumpur
+    commit-message:
+      prefix: chore(ci)
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - id: meta
+        uses: dependabot/fetch-metadata@v2
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,19 @@ Run from the repo root unless noted:
 - `npm run start:server` / `npm run start:web` — run only one workspace's dev server.
 - `npm run build` — `turbo run build` (respects `^build` so `common` builds first). The `web` build runs `tsgo && vite build`, so stale `common/dist/` types surface here as type errors.
 - `npm run test` — runs `vitest` across workspaces. To run a single test file in `api/`: `npm test -w api -- src/lib/jakim.test.ts`. The api package uses `@cloudflare/vitest-pool-workers`, which **requires `api/wrangler.toml` to exist** (see setup below).
-- `npm run typecheck` — `turbo run typecheck`. Only `api/` defines a `typecheck` script (`tsgo`, `noEmit` from tsconfig); `common/` and `web/` get typechecked through their `build` scripts (which both run `tsgo` first).
-- `npm run lint` — `turbo run lint`. Each workspace runs `oxlint --type-aware .`; tsgolint backs the type-aware rules. The `--type-aware` flag must be on the CLI, *not* in `.oxlintrc.json` — oxlint rejects `options.typeAware` when run from a workspace cwd because it treats the parent-found root config as nested.
+- `npm run typecheck` — `turbo run typecheck`. All three workspaces define a `typecheck` script: `api/` and `web/` run `tsgo` (their tsconfigs already set `noEmit`); `common/` runs `tsgo --noEmit` (its tsconfig emits to `dist/`, so the flag is needed to override).
+- `npm run lint` — `turbo run lint`. Each workspace runs `oxlint --type-aware --deny-warnings .`; tsgolint backs the type-aware rules. `--deny-warnings` makes warnings fail CI (and pre-commit). The `--type-aware` flag must be on the CLI, *not* in `.oxlintrc.json` — oxlint rejects `options.typeAware` when run from a workspace cwd because it treats the parent-found root config as nested.
 - `npm run format` / `npm run format:check` — `oxfmt` per workspace, zero-config. Generated files are excluded via `'!path'` patterns in each workspace's `format` script (oxfmt has no `.oxfmtignore` — it reads `.gitignore`/`.prettierignore` only).
 - `npm run deploy -w api` — deploy the Worker via `wrangler deploy --minify`.
+
+### Git hooks (lefthook)
+
+`lefthook.yml` defines two hooks; they self-install on `npm install` via the root `prepare` script.
+
+- **pre-commit** — runs `oxfmt` then `oxlint --fix --deny-warnings` on staged `*.{ts,tsx,js,jsx,mjs,cjs}` files (excluding `web/src/routeTree.gen.ts` and `api/worker-configuration.d.ts`). Fixes are auto-restaged via `stage_fixed: true`. No `--type-aware` here — kept fast (sub-second).
+- **pre-push** — runs `npx turbo run typecheck test lint` (full repo, type-aware). Mirrors what CI cares about so push-time failures match CI.
+
+Bypass: `git commit --no-verify` / `git push --no-verify`, or `LEFTHOOK=0` in the env. CI doesn't need a guard — `npm ci` runs `prepare` and installs hooks into the runner's `.git`, but they only fire on git ops.
 
 When you change anything in `common/src/`, either run `npm -w @kronos/common run dev` (watch mode) or rebuild it; otherwise `api`/`web` will see stale types from `common/dist/`.
 
@@ -70,6 +79,8 @@ All times the api returns are ISO strings in UTC; the web converts to local disp
 
 ## CI/CD
 
-- `.github/workflows/ci.yml` — runs on PR and push to master: `npm ci`, `build`, `typecheck`, `test`, `lint`, `format:check`.
+- `.github/workflows/pr-checks.yml` — runs on PR and push to master: `npm ci`, `build`, `typecheck`, `test`, `lint`, `format:check`. The job key is `check`; that's the name to use in branch protection rulesets (status check names are job IDs, not workflow names, and rulesets don't accept wildcards).
 - `.github/workflows/deploy-api.yml` — deploys the worker on push to master, gated by path filter (`api/**`, `common/**`, `package-lock.json`). Uses `cloudflare/wrangler-action@v3` with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the GitHub `Production` environment.
+- `.github/workflows/dependabot-auto-merge.yml` — listens for PRs from `dependabot[bot]`, uses `dependabot/fetch-metadata@v2` to inspect the update type, and runs `gh pr review --approve` + `gh pr merge --auto --squash` for `semver-patch` / `semver-minor`. Majors fall through and need human review. Auto-merge waits on the required status check, so a red CI blocks the merge.
+- `.github/dependabot.yml` — weekly Monday 06:00 KL time. npm at `/` (covers all three workspaces). Groups: `tanstack` (`@tanstack/*`, all update types), `react` (`react`, `react-dom`, `@types/react*`, all update types), `types` (other `@types/*`, minor+patch only), `minor-and-patch` (catch-all, minor+patch only). Majors of non-grouped deps surface as individual PRs. github-actions also tracked weekly.
 - The web app is deployed by Cloudflare Pages directly (auto-deploy on push to master, configured outside this repo) — no GitHub Actions step for it.

--- a/common/package.json
+++ b/common/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "tsgo --watch",
     "build": "del-cli dist && tsgo",
+    "typecheck": "tsgo --noEmit",
     "lint": "oxlint --type-aware --deny-warnings .",
     "format": "oxfmt",
     "format:check": "oxfmt --check"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,23 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: oxfmt
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs}"
+      exclude:
+        - "web/src/routeTree.gen.ts"
+        - "api/worker-configuration.d.ts"
+      run: npx oxfmt {staged_files}
+      stage_fixed: true
+
+    - name: oxlint
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs}"
+      exclude:
+        - "web/src/routeTree.gen.ts"
+        - "api/worker-configuration.d.ts"
+      run: npx oxlint --fix --deny-warnings {staged_files}
+      stage_fixed: true
+
+pre-push:
+  jobs:
+    - name: turbo
+      run: npx turbo run typecheck test lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@typescript/native-preview": "^7.0.0-dev.20260425.1",
+        "lefthook": "^1.13.6",
         "oxfmt": "^0.46.0",
         "oxlint": "^1.61.0",
         "oxlint-tsgolint": "^0.22.0",
@@ -7759,6 +7760,169 @@
       "funding": {
         "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.13.6.tgz",
+      "integrity": "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.13.6",
+        "lefthook-darwin-x64": "1.13.6",
+        "lefthook-freebsd-arm64": "1.13.6",
+        "lefthook-freebsd-x64": "1.13.6",
+        "lefthook-linux-arm64": "1.13.6",
+        "lefthook-linux-x64": "1.13.6",
+        "lefthook-openbsd-arm64": "1.13.6",
+        "lefthook-openbsd-x64": "1.13.6",
+        "lefthook-windows-arm64": "1.13.6",
+        "lefthook-windows-x64": "1.13.6"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.13.6.tgz",
+      "integrity": "sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.13.6.tgz",
+      "integrity": "sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.13.6.tgz",
+      "integrity": "sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.13.6.tgz",
+      "integrity": "sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.13.6.tgz",
+      "integrity": "sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.13.6.tgz",
+      "integrity": "sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.13.6.tgz",
+      "integrity": "sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.13.6.tgz",
+      "integrity": "sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.13.6.tgz",
+      "integrity": "sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.13.6.tgz",
+      "integrity": "sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "start:server": "npm run dev -w api",
-    "start:web": "npm run dev -w web"
+    "start:web": "npm run dev -w web",
+    "prepare": "lefthook install"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@typescript/native-preview": "^7.0.0-dev.20260425.1",
+    "lefthook": "^1.13.6",
     "oxfmt": "^0.46.0",
     "oxlint": "^1.61.0",
     "oxlint-tsgolint": "^0.22.0",

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "start": "vite",
     "build": "tsgo && vite build",
+    "typecheck": "tsgo",
     "preview": "vite preview",
     "lint": "oxlint --type-aware --deny-warnings .",
     "format": "oxfmt . '!src/routeTree.gen.ts'",


### PR DESCRIPTION
## Summary

- **lefthook** — pre-commit (oxfmt + oxlint --fix on staged TS/JS, no `--type-aware`, ~0.6s) and pre-push (`turbo run typecheck test lint`, full repo). Self-installs via the root `prepare` script — contributors just `npm install`.
- **typecheck** scripts added to `common/` (`tsgo --noEmit`) and `web/` (`tsgo`) so `turbo run typecheck` covers all three workspaces uniformly.
- **dependabot** weekly Monday 06:00 KL with grouped updates: `@tanstack/*` and react family upgrade together (incl. majors, since they share internal API contracts); `@types/*` and a catch-all are minor+patch only; ungrouped majors get individual PRs.
- **Auto-merge workflow** approves and squash-merges Dependabot PRs that are patch/minor and pass required CI; majors fall through for human review.

## Test plan

- [x] `npm install` runs `prepare`; hooks land at `.git/hooks/{pre-commit,pre-push}`
- [x] `turbo run typecheck` covers all 3 workspaces (common, api, web)
- [x] `lefthook run pre-commit` against a real source file finishes in ~0.6s clean
- [x] Pre-push hook ran full `turbo run typecheck test lint` on this push — all green
- [ ] Verify auto-merge workflow on first Dependabot PR (visible after merge to master)
- [ ] Confirm "Allow auto-merge" repo setting is on (already enabled per offline confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)