### PR TITLE
fix prayer time KL day resolution

### DIFF
--- a/api/src/index.test.ts
+++ b/api/src/index.test.ts
@@ -247,6 +247,33 @@ describe("GET /time/manual: upstream + KV cache", () => {
     expect(await env.kronos.get("JHR01-2026")).not.toBeNull();
   });
 
+  it.each([
+    ["midnight KL", "2025-06-15T00:00:00+08:00"],
+    ["mid-afternoon KL", "2025-06-15T15:00:00+08:00"],
+    ["just before midnight KL", "2025-06-15T23:59:00+08:00"],
+    ["UTC ISO same KL day", "2025-06-15T07:00:00Z"],
+    ["non-KL offset same KL day", "2025-06-15T00:00:00-07:00"],
+  ] as const)("resolves %s to the same JAKIM day's entry", async (_label, date) => {
+    stubUpstream();
+    const seeded = [
+      {
+        date: "2025-06-14T00:00:00.000Z",
+        imsak: "2025-06-14T21:42:00.000Z",
+        subuh: "2025-06-14T21:52:00.000Z",
+        syuruk: "2025-06-14T23:15:00.000Z",
+        zohor: "2025-06-15T05:15:00.000Z",
+        asar: "2025-06-15T08:39:00.000Z",
+        maghrib: "2025-06-15T11:13:00.000Z",
+        isyak: "2025-06-15T12:28:00.000Z",
+      },
+    ];
+    await env.kronos.put("JHR01-2025", JSON.stringify(seeded));
+
+    const res = await exports.default.fetch(url("/time/manual", { date, zone: "JHR01" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(seeded[0]);
+  });
+
   it("returns 404 when the requested date is not in the cached year", async () => {
     stubUpstream();
     await env.kronos.put("JHR01-2025", JSON.stringify([]));

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { dateTimeToCommonDay, isoToCommonDateTime, ZONE_OPTIONS, ZoneSchema } from "@kronos/common";
+import { ZONE_OPTIONS, ZoneSchema } from "@kronos/common";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
+import { DateTime } from "luxon";
 import { CustomTimeProvider } from "./lib/time";
 import { JakimProvider } from "./lib/jakim";
 import { ExchangeRateProvider } from "./lib/exchange-rate";
@@ -69,13 +70,18 @@ server.get(
   async (c) => {
     const { date, zone } = c.req.valid("query");
 
-    let datetime = isoToCommonDateTime(date);
+    // Resolve the request to "which JAKIM day does this instant fall in, in
+    // Asia/KL." Cache keys are KL-midnight expressed as the corresponding
+    // UTC instant then floored to UTC startOf("day") (see jakim.ts).
+    const datetime = DateTime.fromISO(date, { setZone: true })
+      .setZone("Asia/Kuala_Lumpur")
+      .startOf("day")
+      .setZone("UTC")
+      .startOf("day");
 
-    if (!datetime) {
+    if (!datetime.isValid) {
       throw new Error("Invalid date given");
     }
-
-    datetime = dateTimeToCommonDay(datetime);
 
     const time = new JakimProvider();
     const res = await time.getTimeForDay(datetime, zone);

--- a/web/src/hooks/use-prayer-time.ts
+++ b/web/src/hooks/use-prayer-time.ts
@@ -7,11 +7,16 @@ import { createKy } from "../api/ky";
 
 const ky = createKy();
 
+// Anchor "today" to Asia/KL — the audience and both providers are KL-bound,
+// so a device in another zone shouldn't shift the day boundary.
+const KL_ZONE = "Asia/Kuala_Lumpur";
+
 export function useAutoPrayerTime(useAdjustment: boolean) {
   const latLong = useAtomValue(latlongAtom);
   const method = useAtomValue(methodAtom);
-  const today: string = DateTime.now().toISO();
-  const _today: string = DateTime.now().startOf("day").toISO();
+  const nowKl = DateTime.now().setZone(KL_ZONE);
+  const today: string = nowKl.toISO() ?? "";
+  const _today: string = nowKl.startOf("day").toISO() ?? "";
 
   return useQuery({
     queryKey: ["time", "auto", _today, useAdjustment],
@@ -35,10 +40,12 @@ export function useAutoPrayerTime(useAdjustment: boolean) {
 export function useManualPrayerTime() {
   const method = useAtomValue(methodAtom);
   const zone = useAtomValue(zoneAtom);
-  const today: string = DateTime.now().toISO();
+  const nowKl = DateTime.now().setZone(KL_ZONE);
+  const today: string = nowKl.toISO() ?? "";
+  const _today: string = nowKl.startOf("day").toISO() ?? "";
 
   return useQuery({
-    queryKey: ["time", "manual", zone],
+    queryKey: ["time", "manual", zone, _today],
     retry: 1,
     retryDelay: 500,
     enabled: zone !== null && method === "manual",


### PR DESCRIPTION
## Summary
- Manual `/time/manual` resolved the requested ISO via `toUTC().startOf("day")`, which after 08:00 KL landed on the *next* JAKIM cache key — users saw tomorrow's prayer times for ~16h of every day. The CLAUDE.md footgun warned about exactly this. Now interpret the ISO in `Asia/KL`, take `startOf("day")` there, then convert to the cache-key shape; correct for any incoming offset (KL, UTC, anything).
- Web hooks now anchor `today`/`_today` to `Asia/KL` for both auto and manual modes, so a non-KL device clock can't shift the day boundary.
- Manual queryKey now includes `_today` so the cached result invalidates at KL midnight (it previously only keyed on `zone` and stayed stale across midnight).

## Test plan
- [x] `npm test` — 882 pass, including 5 new parameterized cases covering midnight KL, mid-afternoon KL, just-before-midnight KL, UTC ISO, and a non-KL offset, all asserting the same seeded JAKIM-day entry. Mid-afternoon KL is the smoking-gun case that returned tomorrow's data before the fix.
- [x] `npm run typecheck`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)