### PR TITLE
add SARS-CoV-2 Malaysia record (folio 06)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,8 @@
     "@kronos/common": "^1.0.0",
     "@types/luxon": "^3.7.1",
     "hono": "^4.12.15",
+    "hyparquet": "^1.25.6",
+    "hyparquet-compressors": "^1.1.1",
     "luxon": "^3.7.2",
     "zod": "^4.3.6"
   },

--- a/api/scripts/inspect-covid-parquet.mjs
+++ b/api/scripts/inspect-covid-parquet.mjs
@@ -1,0 +1,51 @@
+// One-off probe for the data.gov.my COVID-19 parquets. Prints schema, row counts,
+// distinct states, and head/tail samples. Run when MoH publishes anything new
+// (which they have not since June 2025) to verify column names before touching
+// the worker's PandemicProvider.
+//
+//   node scripts/inspect-covid-parquet.mjs
+
+import {
+  asyncBufferFromUrl,
+  parquetMetadataAsync,
+  parquetSchema,
+  parquetReadObjects,
+} from "hyparquet";
+import { compressors } from "hyparquet-compressors";
+
+const SOURCES = [
+  { name: "cases", url: "https://storage.data.gov.my/healthcare/covid_cases.parquet" },
+  { name: "deaths", url: "https://storage.data.gov.my/healthcare/covid_deaths_linelist.parquet" },
+];
+
+for (const { name, url } of SOURCES) {
+  console.log(`\n=== ${name} (${url}) ===`);
+  const file = await asyncBufferFromUrl({ url });
+  const metadata = await parquetMetadataAsync(file);
+  const schema = parquetSchema(metadata);
+  const cols = schema.children.map((c) => `${c.element.name}: ${c.element.type ?? "group"}`);
+  console.log(`columns (${schema.children.length}):`);
+  for (const c of cols) console.log(`  - ${c}`);
+  console.log(`row count: ${metadata.num_rows}`);
+
+  const rows = await parquetReadObjects({ file, compressors, rowStart: 0, rowEnd: 3 });
+  console.log("first 3 rows:");
+  for (const r of rows)
+    console.log(`  ${JSON.stringify(r, (_, v) => (typeof v === "bigint" ? Number(v) : v))}`);
+
+  const last = await parquetReadObjects({
+    file,
+    compressors,
+    rowStart: Number(metadata.num_rows) - 3,
+    rowEnd: Number(metadata.num_rows),
+  });
+  console.log("last 3 rows:");
+  for (const r of last)
+    console.log(`  ${JSON.stringify(r, (_, v) => (typeof v === "bigint" ? Number(v) : v))}`);
+
+  const states = new Set();
+  const all = await parquetReadObjects({ file, compressors, columns: ["state", "date"] });
+  for (const r of all) states.add(r.state);
+  console.log(`distinct states (${states.size}): ${[...states].sort().join(" | ")}`);
+  console.log(`date range: ${all[0]?.date} → ${all[all.length - 1]?.date}`);
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,8 @@ import { DateTime } from "luxon";
 import { CustomTimeProvider } from "./lib/time";
 import { JakimProvider } from "./lib/jakim";
 import { ExchangeRateProvider } from "./lib/exchange-rate";
+import { PandemicProvider } from "./lib/pandemic";
+import { refreshAll } from "./lib/cron-registry";
 import { TimeNotFound, UpstreamParseError } from "./errors/errors";
 
 const server = new Hono();
@@ -96,4 +98,15 @@ server.get("/currency/rates", async (c) => {
   return c.json(rates);
 });
 
-export default server;
+server.get("/pandemic/all", async (c) => {
+  const provider = new PandemicProvider();
+  const data = await provider.getDataset();
+  return c.json(data);
+});
+
+export default {
+  fetch: server.fetch,
+  scheduled(_event: ScheduledController, _env: unknown, ctx: ExecutionContext): void {
+    ctx.waitUntil(refreshAll());
+  },
+};

--- a/api/src/lib/cron-provider.ts
+++ b/api/src/lib/cron-provider.ts
@@ -1,0 +1,41 @@
+import { env } from "cloudflare:workers";
+
+interface Schema<T> {
+  parse(input: unknown): T;
+}
+
+export abstract class CronProvider<T> {
+  abstract readonly kvKey: string;
+  abstract readonly schema: Schema<T>;
+
+  /** TTL in seconds for KV cache. Omit for indefinite. */
+  readonly ttlSeconds?: number;
+
+  /** Fetch upstream and produce the cache value. */
+  protected abstract refresh(): Promise<T>;
+
+  async getCached(): Promise<T | null> {
+    const raw = await env.kronos.get(this.kvKey);
+    if (raw === null) return null;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return this.schema.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+
+  async get(): Promise<T> {
+    const cached = await this.getCached();
+    if (cached !== null) return cached;
+    return this.refreshAndCache();
+  }
+
+  async refreshAndCache(): Promise<T> {
+    const fresh = await this.refresh();
+    const validated = this.schema.parse(fresh);
+    const opts = this.ttlSeconds === undefined ? undefined : { expirationTtl: this.ttlSeconds };
+    await env.kronos.put(this.kvKey, JSON.stringify(validated), opts);
+    return validated;
+  }
+}

--- a/api/src/lib/cron-registry.ts
+++ b/api/src/lib/cron-registry.ts
@@ -1,0 +1,25 @@
+import type { CronProvider } from "./cron-provider";
+import { ExchangeRateProvider } from "./exchange-rate";
+import { PandemicProvider } from "./pandemic";
+
+export function getProviders(): CronProvider<unknown>[] {
+  return [new ExchangeRateProvider(), new PandemicProvider()];
+}
+
+export async function refreshAll(): Promise<void> {
+  const providers = getProviders();
+  const results = await Promise.allSettled(
+    providers.map(async (p) => {
+      await p.refreshAndCache();
+      return p.kvKey;
+    }),
+  );
+  for (const [i, result] of results.entries()) {
+    const key = providers[i]?.kvKey ?? "?";
+    if (result.status === "fulfilled") {
+      console.log(`refreshed ${key}`);
+    } else {
+      console.error(`refresh failed for ${key}:`, result.reason);
+    }
+  }
+}

--- a/api/src/lib/exchange-rate.ts
+++ b/api/src/lib/exchange-rate.ts
@@ -1,12 +1,11 @@
-import { CurrencyRates, CurrencyRatesSchema } from "@kronos/common";
+import { CurrencyRatesSchema, type CurrencyRates } from "@kronos/common";
 import { z } from "zod";
 import { DateTime } from "luxon";
-import { env } from "cloudflare:workers";
+import { CronProvider } from "./cron-provider";
 import { UpstreamParseError } from "../errors/errors";
 
 export const OPEN_ER_API_URL = "https://open.er-api.com/v6/latest/USD";
 export const RATES_KV_KEY = "currency-rates";
-const CACHE_TTL_SECONDS = 60 * 60 * 24;
 
 const upstreamSchema = z.object({
   result: z.literal("success"),
@@ -16,27 +15,17 @@ const upstreamSchema = z.object({
   rates: z.record(z.string().length(3), z.number().positive()),
 });
 
-export class ExchangeRateProvider {
-  async getRates(): Promise<CurrencyRates> {
-    const cached = await this._getCached();
-    if (cached) return cached;
+export class ExchangeRateProvider extends CronProvider<CurrencyRates> {
+  readonly kvKey = RATES_KV_KEY;
+  readonly schema = CurrencyRatesSchema;
+  readonly ttlSeconds = 60 * 60 * 24;
 
-    const fresh = await this._fetchUpstream();
-    await env.kronos.put(RATES_KV_KEY, JSON.stringify(fresh), {
-      expirationTtl: CACHE_TTL_SECONDS,
-    });
-    return fresh;
+  /** Backwards-compatible alias used by the route handler. */
+  getRates(): Promise<CurrencyRates> {
+    return this.get();
   }
 
-  async _getCached(): Promise<CurrencyRates | null> {
-    const raw = await env.kronos.get(RATES_KV_KEY);
-    if (raw === null) return null;
-
-    const parsed: unknown = JSON.parse(raw);
-    return CurrencyRatesSchema.parse(parsed);
-  }
-
-  async _fetchUpstream(): Promise<CurrencyRates> {
+  protected async refresh(): Promise<CurrencyRates> {
     const response: unknown = await (await fetch(OPEN_ER_API_URL)).json();
     const validated = upstreamSchema.safeParse(response);
     if (!validated.success) {

--- a/api/src/lib/pandemic.ts
+++ b/api/src/lib/pandemic.ts
@@ -1,0 +1,181 @@
+import { PandemicDatasetSchema, type PandemicDataset, type PandemicSeries } from "@kronos/common";
+import { DateTime } from "luxon";
+import { CronProvider } from "./cron-provider";
+
+const CASES_URL = "https://storage.data.gov.my/healthcare/covid_cases.parquet";
+const DEATHS_URL = "https://storage.data.gov.my/healthcare/covid_deaths_linelist.parquet";
+
+interface CasesRow {
+  date: string;
+  state: string;
+  cases_new: bigint | number | null;
+}
+
+interface DeathsRow {
+  date: string | Date;
+  state: string;
+}
+
+interface PerStateRange {
+  byState: Record<string, Record<string, number> | undefined>;
+  from: string;
+  to: string;
+}
+
+function isoDay(d: string | Date): string {
+  if (typeof d === "string") return d.slice(0, 10);
+  return d.toISOString().slice(0, 10);
+}
+
+function dayDiff(from: string, to: string): number {
+  return Math.round(
+    DateTime.fromISO(to, { zone: "utc" }).diff(DateTime.fromISO(from, { zone: "utc" }), "days")
+      .days,
+  );
+}
+
+function num(v: bigint | number | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  return typeof v === "bigint" ? Number(v) : v;
+}
+
+function densify({ byState, from, to }: PerStateRange): PandemicSeries {
+  const span = dayDiff(from, to) + 1;
+  const out: Record<string, number[]> = {};
+  for (const [state, perDay] of Object.entries(byState)) {
+    if (perDay === undefined) continue;
+    const arr: number[] = Array.from({ length: span }, () => 0);
+    for (const [date, v] of Object.entries(perDay)) {
+      const i = dayDiff(from, date);
+      if (i >= 0 && i < span) arr[i] = v;
+    }
+    out[state] = arr;
+  }
+  return { from, to, byState: out };
+}
+
+export class PandemicProvider extends CronProvider<PandemicDataset> {
+  readonly kvKey = "pandemic-record-v1";
+  readonly schema = PandemicDatasetSchema;
+
+  getDataset(): Promise<PandemicDataset> {
+    return this.get();
+  }
+
+  protected async refresh(): Promise<PandemicDataset> {
+    const [cases, deaths] = await Promise.all([readCases(), readDeaths()]);
+
+    const states = [
+      ...new Set([...Object.keys(cases.byState), ...Object.keys(deaths.byState)]),
+    ].toSorted((a, b) => {
+      if (a === "Malaysia") return -1;
+      if (b === "Malaysia") return 1;
+      return a.localeCompare(b);
+    });
+
+    return {
+      meta: {
+        source: "MoH Malaysia via data.gov.my",
+        sourceUrls: { cases: CASES_URL, deaths: DEATHS_URL },
+        ingestedAt: new Date().toISOString(),
+        casesFrom: cases.from,
+        casesTo: cases.to,
+        deathsFrom: deaths.from,
+        deathsTo: deaths.to,
+      },
+      states,
+      cases: densify(cases),
+      deaths: densify(deaths),
+    };
+  }
+}
+
+// hyparquet-compressors's `compressors` export eagerly initializes hysnappy,
+// which compiles WASM dynamically — Cloudflare Workers forbids that. We bypass
+// the index by importing only the pure-JS BROTLI decoder, which is what our
+// data.gov.my parquets actually use.
+async function buildCompressors(): Promise<{
+  BROTLI: (input: Uint8Array, length: number) => Uint8Array;
+}> {
+  const brotliMod = (await import("hyparquet-compressors/src/brotli.js")) as {
+    decompressBrotli: (input: Uint8Array, length: number) => Uint8Array;
+  };
+  return { BROTLI: brotliMod.decompressBrotli };
+}
+
+// hyparquet returns Record<string, unknown>[]; the column filter we pass
+// guarantees the shape matches CasesRow / DeathsRow at runtime.
+function intoCasesRows(rows: unknown[]): CasesRow[] {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return rows as CasesRow[];
+}
+
+function intoDeathsRows(rows: unknown[]): DeathsRow[] {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return rows as DeathsRow[];
+}
+
+async function readCases(): Promise<PerStateRange> {
+  const { asyncBufferFromUrl, parquetReadObjects } = await import("hyparquet");
+  const compressors = await buildCompressors();
+  const file = await asyncBufferFromUrl({ url: CASES_URL });
+  const rows = intoCasesRows(
+    await parquetReadObjects({
+      file,
+      compressors,
+      columns: ["date", "state", "cases_new"],
+    }),
+  );
+
+  const byState: Record<string, Record<string, number> | undefined> = {};
+  let minDate: string | null = null;
+  let maxDate: string | null = null;
+  for (const r of rows) {
+    const date = isoDay(r.date);
+    const state = r.state;
+    const v = num(r.cases_new);
+    byState[state] ??= {};
+    byState[state][date] = v;
+    if (minDate === null || date < minDate) minDate = date;
+    if (maxDate === null || date > maxDate) maxDate = date;
+  }
+
+  if (minDate === null || maxDate === null) {
+    throw new Error("cases parquet returned zero rows");
+  }
+  return { byState, from: minDate, to: maxDate };
+}
+
+async function readDeaths(): Promise<PerStateRange> {
+  const { asyncBufferFromUrl, parquetReadObjects } = await import("hyparquet");
+  const compressors = await buildCompressors();
+  const file = await asyncBufferFromUrl({ url: DEATHS_URL });
+  const rows = intoDeathsRows(
+    await parquetReadObjects({
+      file,
+      compressors,
+      columns: ["date", "state"],
+    }),
+  );
+
+  const byState: Record<string, Record<string, number> | undefined> = { Malaysia: {} };
+  let minDate: string | null = null;
+  let maxDate: string | null = null;
+  for (const r of rows) {
+    const date = isoDay(r.date);
+    const state = r.state;
+    byState[state] ??= {};
+    byState[state][date] = (byState[state][date] ?? 0) + 1;
+
+    const malaysia = byState.Malaysia!;
+    malaysia[date] = (malaysia[date] ?? 0) + 1;
+
+    if (minDate === null || date < minDate) minDate = date;
+    if (maxDate === null || date > maxDate) maxDate = date;
+  }
+
+  if (minDate === null || maxDate === null) {
+    throw new Error("deaths parquet returned zero rows");
+  }
+  return { byState, from: minDate, to: maxDate };
+}

--- a/api/src/types/hyparquet-compressors.d.ts
+++ b/api/src/types/hyparquet-compressors.d.ts
@@ -1,0 +1,3 @@
+declare module "hyparquet-compressors/src/brotli.js" {
+  export function decompressBrotli(input: Uint8Array, length: number): Uint8Array;
+}

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -16,3 +16,6 @@ enabled = true
 [[kv_namespaces]]
 binding = "kronos"
 id = "3a29917d96cb494ba2620195b32d447e"
+
+[triggers]
+crons = ["0 18 * * *"]

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -23,6 +23,36 @@ export const CurrencyRatesSchema = z.object({
 
 export type CurrencyRates = z.infer<typeof CurrencyRatesSchema>;
 
+export const PandemicMetricSchema = z.enum(["cases", "deaths"]);
+export type PandemicMetric = z.infer<typeof PandemicMetricSchema>;
+
+export const PandemicSeriesSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+  byState: z.record(z.string(), z.array(z.number())),
+});
+
+export const PandemicMetaSchema = z.object({
+  source: z.string(),
+  sourceUrls: z.object({ cases: z.string(), deaths: z.string() }),
+  ingestedAt: z.iso.datetime({ offset: true }),
+  casesFrom: z.string(),
+  casesTo: z.string(),
+  deathsFrom: z.string(),
+  deathsTo: z.string(),
+});
+
+export const PandemicDatasetSchema = z.object({
+  meta: PandemicMetaSchema,
+  states: z.array(z.string()),
+  cases: PandemicSeriesSchema,
+  deaths: PandemicSeriesSchema,
+});
+
+export type PandemicDataset = z.infer<typeof PandemicDatasetSchema>;
+export type PandemicSeries = z.infer<typeof PandemicSeriesSchema>;
+export type PandemicMeta = z.infer<typeof PandemicMetaSchema>;
+
 export const ZoneSchema = z.enum([
   "JHR01",
   "JHR02",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "@kronos/common": "^1.0.0",
         "@types/luxon": "^3.7.1",
         "hono": "^4.12.15",
+        "hyparquet": "^1.25.6",
+        "hyparquet-compressors": "^1.1.1",
         "luxon": "^3.7.2",
         "zod": "^4.3.6"
       },
@@ -7516,6 +7518,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -7811,6 +7819,28 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/hyparquet": {
+      "version": "1.25.6",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.25.6.tgz",
+      "integrity": "sha512-Q9W5IjkVch3ZMnYd4qFv2q8suu5Jc36yt7J+zUNM9grwnP1S189icp0jdEQKM5HJvQkTVy8NMiQ8n/dM5QAt1A==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
     },
     "node_modules/ico-endec": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
   "name": "kronos",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "packageManager": "npm@11.3.0",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
+  "workspaces": [
+    "api",
+    "web",
+    "common"
+  ],
   "type": "module",
+  "main": "index.js",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run build --filter=@kronos/common --no-daemon && turbo run dev",
@@ -17,14 +24,6 @@
     "start:web": "npm run dev -w web",
     "prepare": "lefthook install"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "workspaces": [
-    "api",
-    "web",
-    "common"
-  ],
   "dependencies": {
     "ky": "^2.0.2",
     "luxon": "^3.7.2"
@@ -37,5 +36,6 @@
     "oxlint-tsgolint": "^0.22.0",
     "turbo": "^2.9.6",
     "vitest": "^4.1.5"
-  }
+  },
+  "packageManager": "npm@11.3.0"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "tsgo && vite build",
     "typecheck": "tsgo",
     "preview": "vite preview",
+    "test": "vitest run",
     "lint": "oxlint --type-aware --deny-warnings .",
     "format": "oxfmt . '!src/routeTree.gen.ts'",
     "format:check": "oxfmt --check . '!src/routeTree.gen.ts'"

--- a/web/public/shortcut-06.svg
+++ b/web/public/shortcut-06.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" fill="#f4ede0"/>
+  <text x="48" y="62" text-anchor="middle" font-family="ui-monospace, 'SF Mono', 'PP Fraktion Mono', monospace" font-size="38" font-weight="400" fill="#1a1612" font-feature-settings="'tnum'">06</text>
+</svg>

--- a/web/src/atoms.ts
+++ b/web/src/atoms.ts
@@ -46,3 +46,21 @@ export const currencyToAtom = atomWithStorage<string>(
   "MYR",
   makeStorage<string>(),
 );
+
+export const pandemicStateAtom = atomWithStorage<string>(
+  "kronos_pandemic_state",
+  "Malaysia",
+  makeStorage<string>(),
+);
+
+export const pandemicCompareAtom = atomWithStorage<string | null>(
+  "kronos_pandemic_compare",
+  null,
+  makeStorage<string | null>(),
+);
+
+export const pandemicYearAtom = atomWithStorage<string>(
+  "kronos_pandemic_year",
+  "all",
+  makeStorage<string>(),
+);

--- a/web/src/components/hairline-chart.tsx
+++ b/web/src/components/hairline-chart.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+interface HairlineChartProps {
+  values: number[];
+  height?: number;
+  highlightIndex?: number | null;
+  onHighlight?: (index: number | null) => void;
+  ariaLabel?: string;
+  overlay?: { values: number[]; ariaLabel?: string } | null;
+}
+
+const DEFAULT_HEIGHT = 180;
+const PADDING_TOP = 6;
+const PADDING_BOTTOM = 14;
+
+const CURSOR_CROSSHAIR_STYLE = { cursor: "crosshair" } as const;
+const CURSOR_DEFAULT_STYLE = { cursor: "default" } as const;
+const noop = (): void => {};
+
+function buildPath(values: number[], width: number, innerHeight: number, max: number): string {
+  if (values.length === 0 || max <= 0) {
+    return `M 0 ${innerHeight} L ${width} ${innerHeight}`;
+  }
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const parts = values.map((v, i) => {
+    const x = i * step;
+    const y = innerHeight - (v / max) * innerHeight;
+    return `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+  });
+  return parts.join(" ");
+}
+
+function buildArea(values: number[], width: number, innerHeight: number, max: number): string {
+  if (values.length === 0 || max <= 0) return "";
+  const line = buildPath(values, width, innerHeight, max);
+  const lastX = values.length > 1 ? width : 0;
+  return `${line} L ${lastX.toFixed(2)} ${innerHeight} L 0 ${innerHeight} Z`;
+}
+
+export function HairlineChart({
+  values,
+  height = DEFAULT_HEIGHT,
+  highlightIndex,
+  onHighlight,
+  ariaLabel,
+  overlay = null,
+}: HairlineChartProps) {
+  const ref = useRef<SVGSVGElement | null>(null);
+  const [width, setWidth] = useState(800);
+  const reactId = useId();
+
+  useEffect(() => {
+    const node = ref.current;
+    if (node === null) {
+      return noop;
+    }
+    const initial = node.getBoundingClientRect().width;
+    if (initial > 0) setWidth(initial);
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const next = entry.contentRect.width;
+      if (next > 0) setWidth(next);
+    });
+    ro.observe(node);
+    return () => {
+      ro.disconnect();
+    };
+  }, []);
+
+  const innerHeight = height - PADDING_TOP - PADDING_BOTTOM;
+  const svgStyle = useMemo(() => ({ height }), [height]);
+
+  const max = useMemo(() => {
+    let m = 0;
+    for (const v of values) if (v > m) m = v;
+    if (overlay) for (const v of overlay.values) if (v > m) m = v;
+    return m;
+  }, [values, overlay]);
+
+  const linePath = useMemo(
+    () => buildPath(values, width, innerHeight, max),
+    [values, width, innerHeight, max],
+  );
+  const areaPath = useMemo(
+    () => buildArea(values, width, innerHeight, max),
+    [values, width, innerHeight, max],
+  );
+  const overlayPath = useMemo(
+    () => (overlay ? buildPath(overlay.values, width, innerHeight, max) : null),
+    [overlay, width, innerHeight, max],
+  );
+
+  const handleMove = (e: React.PointerEvent<SVGRectElement>) => {
+    if (!onHighlight || values.length === 0) return;
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    const ratio = (e.clientX - rect.left) / rect.width;
+    const i = Math.max(0, Math.min(values.length - 1, Math.round(ratio * (values.length - 1))));
+    onHighlight(i);
+  };
+
+  const handleLeave = () => {
+    if (onHighlight) onHighlight(null);
+  };
+
+  const highlightX =
+    highlightIndex !== undefined && highlightIndex !== null && values.length > 1
+      ? (highlightIndex / (values.length - 1)) * width
+      : null;
+
+  return (
+    <svg
+      ref={ref}
+      role="img"
+      aria-label={ariaLabel}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className="block w-full text-ink"
+      style={svgStyle}
+    >
+      <defs>
+        <linearGradient id={`fade-${reactId}`} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <g transform={`translate(0, ${PADDING_TOP})`}>
+        {areaPath !== "" && <path d={areaPath} fill={`url(#fade-${reactId})`} stroke="none" />}
+        {overlayPath !== null && (
+          <path
+            d={overlayPath}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={0.75}
+            strokeOpacity={0.4}
+            strokeDasharray="2 2"
+            strokeLinejoin="round"
+          />
+        )}
+        <path
+          d={linePath}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeLinejoin="round"
+        />
+        {highlightX !== null && (
+          <line
+            x1={highlightX}
+            x2={highlightX}
+            y1={0}
+            y2={innerHeight}
+            stroke="var(--color-accent)"
+            strokeWidth={0.75}
+          />
+        )}
+        <line
+          x1={0}
+          x2={width}
+          y1={innerHeight}
+          y2={innerHeight}
+          stroke="currentColor"
+          strokeWidth={0.5}
+          strokeOpacity={0.45}
+        />
+      </g>
+      <rect
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        fill="transparent"
+        onPointerMove={handleMove}
+        onPointerLeave={handleLeave}
+        style={onHighlight ? CURSOR_CROSSHAIR_STYLE : CURSOR_DEFAULT_STYLE}
+      />
+    </svg>
+  );
+}

--- a/web/src/components/pages/contents.tsx
+++ b/web/src/components/pages/contents.tsx
@@ -14,7 +14,7 @@ const SETTING_DATE = DateTime.fromISO(__BUILD_DATE__).toLocaleString({
 
 interface Entry {
   kind: "live";
-  to: "/prayer-time" | "/currency";
+  to: "/prayer-time" | "/currency" | "/pandemic";
   title: string;
   tagline: string;
   folio: string;
@@ -53,6 +53,13 @@ const sections: Section[] = [
         title: "Currency Converter",
         tagline: "Live foreign exchange rates against the United States dollar.",
         folio: "04",
+      },
+      {
+        kind: "live",
+        to: "/pandemic",
+        title: "SARS-CoV-2, Malaysia",
+        tagline: "A standing record of cases and deaths, drawn from MoH’s linelists.",
+        folio: "06",
       },
       {
         kind: "forthcoming",

--- a/web/src/components/pages/pandemic.tsx
+++ b/web/src/components/pages/pandemic.tsx
@@ -1,0 +1,391 @@
+import { useMemo, useState } from "react";
+import { useAtom } from "jotai";
+import { DateTime } from "luxon";
+import type { PandemicDataset, PandemicMetric } from "@kronos/common";
+import { pandemicCompareAtom, pandemicStateAtom, pandemicYearAtom } from "../../atoms";
+import { usePandemic } from "../../hooks/use-pandemic";
+import { Loading } from "../base/loading";
+import { FolioMark, RunningHead } from "../page-frame";
+import { Imprint } from "../imprint";
+import { QueryErrorBoundary } from "../../query/query-provider";
+import { Switch } from "../base/Switch";
+import { PandemicStateSelector } from "../pandemic-state-selector";
+import { HairlineChart } from "../hairline-chart";
+import { addDays, dayDiff, pickYears, sliceSeries } from "../../lib/pandemic-slice";
+
+const FOLIO = "06";
+const HERO_STYLE = { fontSize: "clamp(4rem,15vw,9rem)" } as const;
+const CASES_THRESHOLD = 1000;
+const DEATHS_THRESHOLD = 10;
+
+function metricLabel(metric: PandemicMetric): string {
+  return metric === "cases" ? "cases" : "deaths";
+}
+
+function fmtInt(n: number): string {
+  return new Intl.NumberFormat("en-US").format(Math.round(n));
+}
+
+function fmtDate(iso: string, opts?: Intl.DateTimeFormatOptions): string {
+  const dt = DateTime.fromISO(iso);
+  return dt.toLocaleString(opts ?? { day: "numeric", month: "long", year: "numeric" });
+}
+
+interface YearTabsProps {
+  available: string[];
+  value: string;
+  onChange: (year: string) => void;
+}
+
+function YearTabs({ available, value, onChange }: YearTabsProps) {
+  const all: { key: string; label: string }[] = [
+    { key: "all", label: "all" },
+    ...available.map((y) => ({ key: y, label: y })),
+  ];
+  return (
+    <div className="flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 kicker">
+      {all.map((t, i) => (
+        <span key={t.key} className="inline-flex items-baseline gap-3">
+          {i > 0 && (
+            <span aria-hidden="true" className="text-ink-faint">
+              ·
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              onChange(t.key);
+            }}
+            className={
+              t.key === value
+                ? "text-accent border-b border-accent pb-px transition-colors cursor-pointer"
+                : "text-ink-mute hover:text-accent transition-colors cursor-pointer"
+            }
+          >
+            {t.label}
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface OnThisDayProps {
+  dataset: PandemicDataset;
+  state: string;
+}
+
+function OnThisDay({ dataset, state }: OnThisDayProps) {
+  const minDate =
+    dataset.cases.from < dataset.deaths.from ? dataset.cases.from : dataset.deaths.from;
+  const maxDate = dataset.cases.to > dataset.deaths.to ? dataset.cases.to : dataset.deaths.to;
+
+  const [date, setDate] = useState<string>("2021-08-26");
+
+  const valid = date >= minDate && date <= maxDate;
+  const casesIdx = dayDiff(dataset.cases.from, date);
+  const deathsIdx = dayDiff(dataset.deaths.from, date);
+  const casesValues = dataset.cases.byState[state];
+  const deathsValues = dataset.deaths.byState[state];
+
+  const inCasesRange = valid && date >= dataset.cases.from && date <= dataset.cases.to;
+  const inDeathsRange = valid && date >= dataset.deaths.from && date <= dataset.deaths.to;
+
+  const casesValue =
+    inCasesRange && casesValues !== undefined && casesIdx >= 0 && casesIdx < casesValues.length
+      ? (casesValues[casesIdx] ?? 0)
+      : null;
+  const deathsValue =
+    inDeathsRange && deathsValues !== undefined && deathsIdx >= 0 && deathsIdx < deathsValues.length
+      ? (deathsValues[deathsIdx] ?? 0)
+      : null;
+
+  return (
+    <section className="flex flex-col gap-5 pt-4">
+      <div className="flex items-baseline gap-3">
+        <span className="kicker text-ink-mute">On this day</span>
+        <span className="flex-1 border-t border-dotted border-rule translate-y-[-0.3rem]" />
+        <span className="marginalia">{state}</span>
+      </div>
+      <input
+        type="date"
+        value={date}
+        min={minDate}
+        max={maxDate}
+        onChange={(e) => {
+          setDate(e.target.value);
+        }}
+        className="bg-transparent border-0 border-b border-rule focus:border-accent focus:border-b-2 outline-none font-display italic text-lg text-ink py-2 px-0 transition-colors w-full max-w-xs"
+      />
+      {!valid && (
+        <div className="font-display italic text-ink-quiet">
+          The record does not extend to that day.
+        </div>
+      )}
+      {valid && (
+        <div className="grid grid-cols-2 gap-6">
+          <div className="flex flex-col">
+            <span className="kicker text-ink-mute">Cases</span>
+            <span className="font-display italic text-3xl sm:text-4xl text-ink tabular mt-1">
+              {casesValue === null ? "—" : fmtInt(casesValue)}
+            </span>
+            {!inCasesRange && (
+              <span className="marginalia mt-1">
+                cases record ended{" "}
+                {fmtDate(dataset.cases.to, { day: "numeric", month: "short", year: "numeric" })}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-col">
+            <span className="kicker text-ink-mute">Deaths</span>
+            <span className="font-display italic text-3xl sm:text-4xl text-ink tabular mt-1">
+              {deathsValue === null ? "—" : fmtInt(deathsValue)}
+            </span>
+            {!inDeathsRange && (
+              <span className="marginalia mt-1">
+                deaths record ended{" "}
+                {fmtDate(dataset.deaths.to, { day: "numeric", month: "short", year: "numeric" })}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PageContent() {
+  const { data: dataset, isLoading, dataUpdatedAt } = usePandemic();
+  const [state, setState] = useAtom(pandemicStateAtom);
+  const [compare, setCompare] = useAtom(pandemicCompareAtom);
+  const [year, setYear] = useAtom(pandemicYearAtom);
+  const [metric, setMetric] = useState<PandemicMetric>("cases");
+  const [highlight, setHighlight] = useState<number | null>(null);
+
+  const series = dataset === undefined ? null : dataset[metric];
+  const threshold = metric === "cases" ? CASES_THRESHOLD : DEATHS_THRESHOLD;
+  const years = useMemo(
+    () => (dataset === undefined ? [] : pickYears(dataset[metric].from, dataset[metric].to)),
+    [dataset, metric],
+  );
+  const effectiveYear = year === "all" || years.includes(year) ? year : "all";
+  const slice = useMemo(
+    () => (series === null ? null : sliceSeries(series, state, effectiveYear, threshold)),
+    [series, state, effectiveYear, threshold],
+  );
+  const effectiveCompare = compare !== null && compare !== "" && compare !== state ? compare : null;
+  const compareSlice = useMemo(
+    () =>
+      series !== null && effectiveCompare !== null
+        ? sliceSeries(series, effectiveCompare, effectiveYear, threshold)
+        : null,
+    [series, effectiveCompare, effectiveYear, threshold],
+  );
+  const otherStates = useMemo(
+    () => (dataset === undefined ? [] : dataset.states.filter((s) => s !== state)),
+    [dataset, state],
+  );
+  const overlayProp = useMemo(
+    () =>
+      compareSlice === null
+        ? null
+        : { values: compareSlice.values, ariaLabel: effectiveCompare ?? "" },
+    [compareSlice, effectiveCompare],
+  );
+
+  if (isLoading || !dataset || !slice || !series) {
+    return (
+      <div className="reveal-stack mx-auto w-full max-w-3xl flex flex-col gap-10">
+        <RunningHead section="Pandemic" folio={FOLIO} />
+        <div className="flex justify-center pt-20">
+          <Loading>setting the record</Loading>
+        </div>
+      </div>
+    );
+  }
+
+  const period =
+    effectiveYear === "all"
+      ? `${fmtDate(slice.from, { year: "numeric" })}–${fmtDate(slice.to, { year: "numeric" })}`
+      : effectiveYear;
+
+  const highlightDate = highlight === null ? null : addDays(slice.from, highlight);
+  const highlightValue =
+    highlight === null || highlight >= slice.values.length ? null : (slice.values[highlight] ?? 0);
+  const highlightCompare =
+    compareSlice === null || highlight === null || highlight >= compareSlice.values.length
+      ? null
+      : (compareSlice.values[highlight] ?? 0);
+  const compareLabel = effectiveCompare;
+
+  const dailyAvg = slice.mean;
+
+  return (
+    <div className="reveal-stack mx-auto w-full max-w-3xl flex flex-col gap-12">
+      <RunningHead section="Pandemic" folio={FOLIO} />
+      <Imprint setAt={dataUpdatedAt} />
+
+      <header className="text-center flex flex-col gap-3">
+        <div className="kicker text-ink-mute">SARS-CoV-2 · Malaysia</div>
+        <div className="font-display italic text-2xl sm:text-3xl text-ink-quiet max-w-[42ch] mx-auto">
+          A standing record of cases and deaths, set from MoH&rsquo;s linelists.
+        </div>
+      </header>
+
+      <div className="flex justify-center">
+        <Switch
+          isSelected={metric === "deaths"}
+          onChange={(b) => {
+            setMetric(b ? "deaths" : "cases");
+          }}
+          offLabel="cases"
+          onLabel="deaths"
+        >
+          Reading
+        </Switch>
+      </div>
+
+      <section className="flex flex-col items-center text-center gap-4">
+        <div className="kicker text-accent">
+          <span className="text-ink-faint">·</span> {state}{" "}
+          <span className="text-ink-faint">·</span> {period}{" "}
+          <span className="text-ink-faint">·</span>
+        </div>
+        <div
+          className="font-display italic text-ink tabular leading-[0.92] tracking-tight"
+          style={HERO_STYLE}
+        >
+          {fmtInt(slice.total)}
+        </div>
+        <div className="font-display italic text-base sm:text-lg text-ink-quiet max-w-[44ch]">
+          {metricLabel(metric)} recorded across the period.
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 border-t border-b border-rule-soft py-6">
+        <div className="flex flex-col gap-1">
+          <span className="kicker text-ink-mute">Peak day</span>
+          {slice.peak ? (
+            <>
+              <span className="font-display italic text-xl text-ink">
+                {fmtDate(slice.peak.date, { day: "numeric", month: "short", year: "2-digit" })}
+              </span>
+              <span className="font-mono tabular text-xs text-ink-quiet">
+                {fmtInt(slice.peak.value)} {metricLabel(metric)}
+              </span>
+            </>
+          ) : (
+            <span className="font-display italic text-ink-quiet">—</span>
+          )}
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="kicker text-ink-mute">Daily mean</span>
+          <span className="font-display italic text-xl text-ink tabular">{fmtInt(dailyAvg)}</span>
+          <span className="font-mono tabular text-xs text-ink-quiet">
+            across {slice.values.length} days
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="kicker text-ink-mute">Days ≥ {metric === "cases" ? "1,000" : "10"}</span>
+          <span className="font-display italic text-xl text-ink tabular">
+            {fmtInt(slice.daysOverThreshold)}
+          </span>
+          <span className="font-mono tabular text-xs text-ink-quiet">of {slice.values.length}</span>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <span className="kicker text-ink-mute">Curve</span>
+          <span className="flex-1 border-t border-dotted border-rule translate-y-[-0.3rem]" />
+          <span className="marginalia">
+            {fmtDate(slice.from, { day: "numeric", month: "short", year: "2-digit" })} —{" "}
+            {fmtDate(slice.to, { day: "numeric", month: "short", year: "2-digit" })}
+          </span>
+        </div>
+        <HairlineChart
+          values={slice.values}
+          highlightIndex={highlight}
+          onHighlight={setHighlight}
+          ariaLabel={`Daily ${metric} for ${state}, ${period}`}
+          overlay={overlayProp}
+        />
+        <div className="flex items-baseline justify-between min-h-[1.5rem]">
+          <span className="font-mono tabular text-xs text-ink-mute">
+            {highlightDate === null
+              ? ""
+              : fmtDate(highlightDate, { day: "numeric", month: "long", year: "numeric" })}
+          </span>
+          <span className="font-mono tabular text-xs text-ink">
+            {highlightValue === null ? "" : `${fmtInt(highlightValue)} ${state}`}
+            {highlightCompare !== null && compareLabel !== null ? (
+              <span className="text-ink-mute">
+                {" · "}
+                {fmtInt(highlightCompare)} {compareLabel}
+              </span>
+            ) : null}
+          </span>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-6">
+        <div className="flex items-baseline gap-3">
+          <span className="kicker text-ink-mute">Set the reading</span>
+          <span className="flex-1 border-t border-rule" />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="kicker text-ink-mute">Year</span>
+          <YearTabs available={years} value={effectiveYear} onChange={(y) => void setYear(y)} />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <PandemicStateSelector
+            label="State"
+            value={state}
+            onChange={(s) => void setState(s ?? "Malaysia")}
+            states={dataset.states}
+          />
+          <PandemicStateSelector
+            label="Compare with"
+            value={compare}
+            onChange={(s) => void setCompare(s)}
+            states={otherStates}
+            placeholder="(none)"
+            allowClear
+          />
+        </div>
+      </section>
+
+      <OnThisDay dataset={dataset} state={state} />
+
+      <section className="border-t border-rule-soft pt-6 flex flex-col gap-2">
+        <span className="kicker text-ink-mute">Source</span>
+        <p className="font-display italic text-sm text-ink-quiet leading-relaxed max-w-[58ch]">
+          MoH Malaysia, via{" "}
+          <a
+            href="https://data.gov.my"
+            className="text-accent hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            data.gov.my
+          </a>
+          . Cases compiled from the daily epidemic series; deaths from the linelist, one row per
+          person. The cases record terminates {fmtDate(dataset.meta.casesTo)}; the deaths linelist
+          terminates {fmtDate(dataset.meta.deathsTo)}.
+        </p>
+      </section>
+
+      <FolioMark folio={FOLIO} />
+    </div>
+  );
+}
+
+export function PandemicPage() {
+  return (
+    <QueryErrorBoundary>
+      <PageContent />
+    </QueryErrorBoundary>
+  );
+}

--- a/web/src/components/pandemic-state-selector.tsx
+++ b/web/src/components/pandemic-state-selector.tsx
@@ -1,0 +1,44 @@
+import type { Key } from "react-aria";
+import { ComboBox } from "./base/combo-box";
+
+interface Props {
+  value: string | null;
+  onChange: (state: string | null) => void;
+  states: string[];
+  label?: string;
+  placeholder?: string;
+  allowClear?: boolean;
+}
+
+export function PandemicStateSelector({
+  value,
+  onChange,
+  states,
+  label,
+  placeholder = "Choose a state",
+  allowClear = false,
+}: Props) {
+  const handleChange = (next: Key | null) => {
+    if (next === null) {
+      if (allowClear) onChange(null);
+      return;
+    }
+    onChange(String(next));
+  };
+
+  return (
+    <ComboBox
+      {...(label === undefined ? {} : { label })}
+      value={value}
+      onChange={handleChange}
+      placeholder={placeholder}
+      allowsEmptyCollection
+    >
+      {states.map((state) => (
+        <ComboBox.Item key={state} id={state}>
+          {state}
+        </ComboBox.Item>
+      ))}
+    </ComboBox>
+  );
+}

--- a/web/src/hooks/use-pandemic.ts
+++ b/web/src/hooks/use-pandemic.ts
@@ -1,0 +1,18 @@
+import { PandemicDatasetSchema, type PandemicDataset } from "@kronos/common";
+import { useQuery } from "@tanstack/react-query";
+import { createKy } from "../api/ky";
+
+const ky = createKy();
+
+export function usePandemic() {
+  return useQuery<PandemicDataset>({
+    queryKey: ["pandemic", "all"],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: 1,
+    queryFn: async () => {
+      const body: unknown = await ky.get("pandemic/all").json();
+      return PandemicDatasetSchema.parse(body);
+    },
+  });
+}

--- a/web/src/lib/pandemic-slice.test.ts
+++ b/web/src/lib/pandemic-slice.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { PandemicSeries } from "@kronos/common";
+import { addDays, dayDiff, pickYears, sliceSeries } from "./pandemic-slice";
+
+describe("dayDiff", () => {
+  it("returns 0 for the same date", () => {
+    expect(dayDiff("2020-01-01", "2020-01-01")).toBe(0);
+  });
+
+  it("returns 1 for consecutive days", () => {
+    expect(dayDiff("2020-01-01", "2020-01-02")).toBe(1);
+  });
+
+  it("returns 365 across a non-leap year", () => {
+    expect(dayDiff("2021-01-01", "2022-01-01")).toBe(365);
+  });
+
+  it("returns 366 across a leap year", () => {
+    expect(dayDiff("2020-01-01", "2021-01-01")).toBe(366);
+  });
+
+  it("crosses DST boundaries without rounding error", () => {
+    expect(dayDiff("2025-03-08", "2025-03-10")).toBe(2);
+    expect(dayDiff("2025-11-01", "2025-11-03")).toBe(2);
+  });
+
+  it("handles negative differences", () => {
+    expect(dayDiff("2020-01-10", "2020-01-01")).toBe(-9);
+  });
+});
+
+describe("addDays", () => {
+  it("adds zero days as a no-op", () => {
+    expect(addDays("2021-08-26", 0)).toBe("2021-08-26");
+  });
+
+  it("rolls month boundaries", () => {
+    expect(addDays("2021-01-31", 1)).toBe("2021-02-01");
+  });
+
+  it("rolls year boundaries", () => {
+    expect(addDays("2020-12-31", 1)).toBe("2021-01-01");
+  });
+
+  it("handles leap day correctly", () => {
+    expect(addDays("2020-02-28", 1)).toBe("2020-02-29");
+    expect(addDays("2020-02-29", 1)).toBe("2020-03-01");
+  });
+
+  it("subtracts days with a negative offset", () => {
+    expect(addDays("2021-01-01", -1)).toBe("2020-12-31");
+  });
+});
+
+describe("pickYears", () => {
+  it("emits a single year when from and to share a year", () => {
+    expect(pickYears("2021-03-01", "2021-12-31")).toEqual(["2021"]);
+  });
+
+  it("emits the full inclusive range across years", () => {
+    expect(pickYears("2020-01-25", "2025-05-31")).toEqual([
+      "2020",
+      "2021",
+      "2022",
+      "2023",
+      "2024",
+      "2025",
+    ]);
+  });
+});
+
+function fixtureSeries(): PandemicSeries {
+  // Two-year series, 5 days per year for compact reasoning.
+  // Day index 0 → 2020-01-01.
+  return {
+    from: "2020-01-01",
+    to: "2021-12-31",
+    byState: {
+      Malaysia: makeValues("2020-01-01", "2021-12-31", (i) => (i % 7 === 0 ? 1500 : 50)),
+      Selangor: makeValues("2020-01-01", "2021-12-31", () => 100),
+    },
+  };
+}
+
+function makeValues(from: string, to: string, fn: (i: number) => number): number[] {
+  const span = dayDiff(from, to) + 1;
+  return Array.from({ length: span }, (_, i) => fn(i));
+}
+
+describe("sliceSeries", () => {
+  it("returns the full range with year='all'", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Malaysia", "all");
+    expect(result.from).toBe("2020-01-01");
+    expect(result.to).toBe("2021-12-31");
+    expect(result.values.length).toBe(dayDiff("2020-01-01", "2021-12-31") + 1);
+  });
+
+  it("filters to a specific year", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Malaysia", "2021");
+    expect(result.from).toBe("2021-01-01");
+    expect(result.to).toBe("2021-12-31");
+    expect(result.values.length).toBe(365);
+  });
+
+  it("handles a leap year correctly", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Malaysia", "2020");
+    expect(result.values.length).toBe(366);
+  });
+
+  it("clamps to series bounds when year extends past data", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Malaysia", "2022");
+    expect(result.values).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.peak).toBeNull();
+  });
+
+  it("clamps to series bounds when year is before data", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Malaysia", "2019");
+    expect(result.values).toEqual([]);
+  });
+
+  it("returns zeroed result for an unknown state", () => {
+    const series = fixtureSeries();
+    const result = sliceSeries(series, "Atlantis", "all");
+    expect(result.values).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.peak).toBeNull();
+    expect(result.mean).toBe(0);
+  });
+
+  it("computes peak and total correctly", () => {
+    const series: PandemicSeries = {
+      from: "2020-01-01",
+      to: "2020-01-05",
+      byState: { Malaysia: [10, 50, 200, 30, 5] },
+    };
+    const result = sliceSeries(series, "Malaysia", "all");
+    expect(result.total).toBe(295);
+    expect(result.peak).toEqual({ date: "2020-01-03", value: 200 });
+    expect(result.mean).toBeCloseTo(59);
+  });
+
+  it("counts daysOverThreshold inclusively at the threshold value", () => {
+    const series: PandemicSeries = {
+      from: "2020-01-01",
+      to: "2020-01-05",
+      byState: { Malaysia: [999, 1000, 1001, 0, 5000] },
+    };
+    const result = sliceSeries(series, "Malaysia", "all", 1000);
+    expect(result.daysOverThreshold).toBe(3);
+  });
+
+  it("handles an all-zero series with no peak", () => {
+    const series: PandemicSeries = {
+      from: "2020-01-01",
+      to: "2020-01-03",
+      byState: { Malaysia: [0, 0, 0] },
+    };
+    const result = sliceSeries(series, "Malaysia", "all");
+    expect(result.total).toBe(0);
+    expect(result.peak).toBeNull();
+    expect(result.mean).toBe(0);
+  });
+
+  it("handles partial first year (data starts mid-year)", () => {
+    const series: PandemicSeries = {
+      from: "2020-06-01",
+      to: "2020-12-31",
+      byState: { Malaysia: makeValues("2020-06-01", "2020-12-31", () => 1) },
+    };
+    const result = sliceSeries(series, "Malaysia", "2020");
+    expect(result.from).toBe("2020-06-01");
+    expect(result.to).toBe("2020-12-31");
+    expect(result.values.length).toBe(dayDiff("2020-06-01", "2020-12-31") + 1);
+  });
+});

--- a/web/src/lib/pandemic-slice.ts
+++ b/web/src/lib/pandemic-slice.ts
@@ -1,0 +1,90 @@
+import { DateTime } from "luxon";
+import type { PandemicSeries } from "@kronos/common";
+
+export interface SliceResult {
+  values: number[];
+  from: string;
+  to: string;
+  total: number;
+  peak: { date: string; value: number } | null;
+  mean: number;
+  daysOverThreshold: number;
+}
+
+export function dayDiff(from: string, to: string): number {
+  return Math.round(
+    DateTime.fromISO(to, { zone: "utc" }).diff(DateTime.fromISO(from, { zone: "utc" }), "days")
+      .days,
+  );
+}
+
+export function addDays(from: string, n: number): string {
+  return DateTime.fromISO(from, { zone: "utc" }).plus({ days: n }).toISODate() ?? from;
+}
+
+export function pickYears(from: string, to: string): string[] {
+  const start = DateTime.fromISO(from, { zone: "utc" }).year;
+  const end = DateTime.fromISO(to, { zone: "utc" }).year;
+  const out: string[] = [];
+  for (let y = start; y <= end; y++) out.push(String(y));
+  return out;
+}
+
+const DEFAULT_THRESHOLD = 1000;
+
+export function sliceSeries(
+  series: PandemicSeries,
+  state: string,
+  year: string,
+  threshold: number = DEFAULT_THRESHOLD,
+): SliceResult {
+  const fullValues = series.byState[state] ?? [];
+  const seriesFrom = series.from;
+
+  let startIdx = 0;
+  let endIdx = fullValues.length - 1;
+  let from = seriesFrom;
+  let to = series.to;
+
+  if (year !== "all") {
+    const yearStart = `${year}-01-01`;
+    const yearEnd = `${year}-12-31`;
+    const startOffset = dayDiff(seriesFrom, yearStart);
+    const endOffset = dayDiff(seriesFrom, yearEnd);
+    startIdx = Math.max(0, startOffset);
+    endIdx = Math.min(fullValues.length - 1, endOffset);
+    if (startIdx > endIdx) {
+      return {
+        values: [],
+        from: yearStart,
+        to: yearEnd,
+        total: 0,
+        peak: null,
+        mean: 0,
+        daysOverThreshold: 0,
+      };
+    }
+    from = addDays(seriesFrom, startIdx);
+    to = addDays(seriesFrom, endIdx);
+  }
+
+  const values = fullValues.slice(startIdx, endIdx + 1);
+  let total = 0;
+  let peakIdx = -1;
+  let peakValue = -1;
+  let daysOver = 0;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i] ?? 0;
+    total += v;
+    if (v > peakValue) {
+      peakValue = v;
+      peakIdx = i;
+    }
+    if (v >= threshold) daysOver++;
+  }
+  const peak =
+    peakIdx >= 0 && peakValue > 0 ? { date: addDays(from, peakIdx), value: peakValue } : null;
+  const mean = values.length > 0 ? total / values.length : 0;
+
+  return { values, from, to, total, peak, mean, daysOverThreshold: daysOver };
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as PrayerTimeRouteImport } from './routes/prayer-time'
+import { Route as PandemicRouteImport } from './routes/pandemic'
 import { Route as CurrencyRouteImport } from './routes/currency'
 import { Route as IndexRouteImport } from './routes/index'
 
 const PrayerTimeRoute = PrayerTimeRouteImport.update({
   id: '/prayer-time',
   path: '/prayer-time',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PandemicRoute = PandemicRouteImport.update({
+  id: '/pandemic',
+  path: '/pandemic',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CurrencyRoute = CurrencyRouteImport.update({
@@ -32,30 +38,34 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/currency': typeof CurrencyRoute
+  '/pandemic': typeof PandemicRoute
   '/prayer-time': typeof PrayerTimeRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/currency': typeof CurrencyRoute
+  '/pandemic': typeof PandemicRoute
   '/prayer-time': typeof PrayerTimeRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/currency': typeof CurrencyRoute
+  '/pandemic': typeof PandemicRoute
   '/prayer-time': typeof PrayerTimeRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/currency' | '/prayer-time'
+  fullPaths: '/' | '/currency' | '/pandemic' | '/prayer-time'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/currency' | '/prayer-time'
-  id: '__root__' | '/' | '/currency' | '/prayer-time'
+  to: '/' | '/currency' | '/pandemic' | '/prayer-time'
+  id: '__root__' | '/' | '/currency' | '/pandemic' | '/prayer-time'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CurrencyRoute: typeof CurrencyRoute
+  PandemicRoute: typeof PandemicRoute
   PrayerTimeRoute: typeof PrayerTimeRoute
 }
 
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/prayer-time'
       fullPath: '/prayer-time'
       preLoaderRoute: typeof PrayerTimeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pandemic': {
+      id: '/pandemic'
+      path: '/pandemic'
+      fullPath: '/pandemic'
+      preLoaderRoute: typeof PandemicRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/currency': {
@@ -88,6 +105,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CurrencyRoute: CurrencyRoute,
+  PandemicRoute: PandemicRoute,
   PrayerTimeRoute: PrayerTimeRoute,
 }
 export const routeTree = rootRouteImport

--- a/web/src/routes/pandemic.tsx
+++ b/web/src/routes/pandemic.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PandemicPage } from "../components/pages/pandemic";
+
+export const Route = createFileRoute("/pandemic")({
+  component: PandemicPage,
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
       return "http://localhost:4305";
     }
   })();
-  const apiPattern = new RegExp(`^${escapeRegex(apiOrigin)}/(time|currency)/`);
+  const apiPattern = new RegExp(`^${escapeRegex(apiOrigin)}/(time|currency|pandemic)/`);
 
   return {
     define: {
@@ -120,6 +120,13 @@ export default defineConfig(({ mode }) => {
               url: "/currency?source=shortcut",
               description: "FX rates against the United States dollar.",
               icons: [{ src: "/shortcut-04.svg", sizes: "96x96", type: "image/svg+xml" }],
+            },
+            {
+              name: "Pandemic Record",
+              short_name: "Pandemic",
+              url: "/pandemic?source=shortcut",
+              description: "Malaysian COVID-19 cases and deaths, 2020–2025.",
+              icons: [{ src: "/shortcut-06.svg", sizes: "96x96", type: "image/svg+xml" }],
             },
           ],
           screenshots: [


### PR DESCRIPTION
## Summary
- New utility at `/pandemic` — typeset hero numeral, hairline epidemic curve drawn as raw SVG, state + compare comboboxes, year tabs, on-this-day date lookup. Editorial idiom; no chart library.
- Worker fetches and parses MoH parquets from data.gov.my at refresh time. The cases series and deaths linelist are aggregated to per-state-per-day in a `CronProvider` and cached in KV.
- New `CronProvider` base class so future fetch+cache+serve datasets follow the same shape. `ExchangeRateProvider` migrated to it; daily cron at 18:00 UTC keeps both providers warm.
- Hyparquet-compressors's BROTLI decoder is imported by subpath (`hyparquet-compressors/src/brotli.js`) instead of via the package index, which would eagerly initialize the hysnappy WASM SNAPPY codec — Cloudflare Workers forbids dynamic WASM compilation.

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run test` — green (882 api tests + 23 new `sliceSeries` tests)
- [x] `npm run format:check` — green
- [x] `npm run build` — green
- [x] Wrangler dev smoke: cold `/pandemic/all` 1.25 s (parses both parquets), warm 4 ms (KV hit), `/__scheduled` triggers `refreshed currency-rates` and `refreshed pandemic-record-v1`
- [x] Browser visual check — hero numeral, year filter, metric switch (cases/deaths), state selector, comparison overlay, on-this-day lookup, theme toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)