### PR TITLE
pandemic: editorial redesign — chapters, inline pickers, drawn curve

### DIFF
--- a/web/src/components/hairline-chart.tsx
+++ b/web/src/components/hairline-chart.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { DateTime } from "luxon";
+
+interface ChartEvent {
+  date: string;
+  label: string;
+}
 
 interface HairlineChartProps {
   values: number[];
@@ -6,15 +12,24 @@ interface HairlineChartProps {
   highlightIndex?: number | null;
   onHighlight?: (index: number | null) => void;
   ariaLabel?: string;
-  overlay?: { values: number[]; ariaLabel?: string } | null;
+  from?: string;
+  to?: string;
+  events?: ChartEvent[];
+  primaryLabel?: string;
+  hoverFormat?: (index: number) => { date: string; primary: string; compare?: string | null };
+  overlay?: { values: number[]; label?: string } | null;
 }
 
-const DEFAULT_HEIGHT = 180;
-const PADDING_TOP = 6;
-const PADDING_BOTTOM = 14;
+const DEFAULT_HEIGHT = 320;
+const PADDING_TOP = 50;
+const PADDING_BOTTOM = 22;
+const PADDING_RIGHT = 80;
+const ANNOTATION_OFFSET = 12;
 
 const CURSOR_CROSSHAIR_STYLE = { cursor: "crosshair" } as const;
 const CURSOR_DEFAULT_STYLE = { cursor: "default" } as const;
+const ENDLABEL_STYLE = { letterSpacing: "0.08em", textTransform: "uppercase" } as const;
+const YEARLABEL_STYLE = { letterSpacing: "0.06em" } as const;
 const noop = (): void => {};
 
 function buildPath(values: number[], width: number, innerHeight: number, max: number): string {
@@ -37,20 +52,134 @@ function buildArea(values: number[], width: number, innerHeight: number, max: nu
   return `${line} L ${lastX.toFixed(2)} ${innerHeight} L 0 ${innerHeight} Z`;
 }
 
+interface EventAnnotationProps {
+  x: number;
+  row: number;
+  label: string;
+}
+
+function EventAnnotation({ x, row, label }: EventAnnotationProps) {
+  const style = useMemo(
+    () => ({ left: x, top: row === 0 ? 0 : 14, transform: "translateX(-50%)", maxWidth: 140 }),
+    [x, row],
+  );
+  return (
+    <div
+      className="absolute marginalia text-ink-mute pointer-events-none whitespace-nowrap"
+      style={style}
+    >
+      {label}
+    </div>
+  );
+}
+
+interface HoverAnnotationProps {
+  left: number;
+  top: number;
+  date: string;
+  primary: string;
+  compare: string | null;
+}
+
+function HoverAnnotation({ left, top, date, primary, compare }: HoverAnnotationProps) {
+  const style = useMemo(() => ({ left, top }), [left, top]);
+  return (
+    <div className="absolute pointer-events-none flex flex-col items-start" style={style}>
+      <span className="font-mono tabular text-[10px] text-ink-mute uppercase tracking-wider">
+        {date}
+      </span>
+      <span className="font-display italic text-base text-ink tabular leading-tight mt-0.5">
+        {primary}
+      </span>
+      {compare !== null && (
+        <span className="font-display italic text-sm text-ink-mute tabular leading-tight">
+          {compare}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function indexFor(date: string, from: string, total: number): number {
+  const a = DateTime.fromISO(from, { zone: "utc" });
+  const b = DateTime.fromISO(date, { zone: "utc" });
+  const days = Math.round(b.diff(a, "days").days);
+  if (days < 0 || days >= total) return -1;
+  return days;
+}
+
+function yAtIndex(values: number[], i: number, innerHeight: number, max: number): number {
+  if (i < 0 || i >= values.length || max <= 0) return innerHeight;
+  return innerHeight - ((values[i] ?? 0) / max) * innerHeight;
+}
+
+interface YearMark {
+  x: number;
+  label: string;
+}
+
+interface YearLabel {
+  x: number;
+  label: string;
+}
+
+function yearBoundaries(from: string, to: string, total: number, plotWidth: number): YearMark[] {
+  if (total <= 1) return [];
+  const start = DateTime.fromISO(from, { zone: "utc" }).year;
+  const end = DateTime.fromISO(to, { zone: "utc" }).year;
+  const marks: YearMark[] = [];
+  for (let y = start + 1; y <= end; y++) {
+    const date = `${y}-01-01`;
+    const i = indexFor(date, from, total);
+    if (i < 0) continue;
+    const x = (i / (total - 1)) * plotWidth;
+    marks.push({ x, label: String(y).slice(-2) });
+  }
+  return marks;
+}
+
+function yearMidpointLabels(
+  from: string,
+  to: string,
+  total: number,
+  plotWidth: number,
+): YearLabel[] {
+  if (total <= 1) return [];
+  const startYear = DateTime.fromISO(from, { zone: "utc" }).year;
+  const endYear = DateTime.fromISO(to, { zone: "utc" }).year;
+  const labels: YearLabel[] = [];
+  for (let y = startYear; y <= endYear; y++) {
+    const slotStart = y === startYear ? from : `${y}-01-01`;
+    const slotEnd = y === endYear ? to : `${y}-12-31`;
+    const iStart = indexFor(slotStart, from, total);
+    const iEnd = indexFor(slotEnd, from, total);
+    if (iStart < 0 || iEnd < 0) continue;
+    const xStart = (iStart / (total - 1)) * plotWidth;
+    const xEnd = (iEnd / (total - 1)) * plotWidth;
+    labels.push({ x: (xStart + xEnd) / 2, label: String(y).slice(-2) });
+  }
+  return labels;
+}
+
 export function HairlineChart({
   values,
   height = DEFAULT_HEIGHT,
   highlightIndex,
   onHighlight,
   ariaLabel,
+  from,
+  to,
+  events = [],
+  primaryLabel,
+  hoverFormat,
   overlay = null,
 }: HairlineChartProps) {
-  const ref = useRef<SVGSVGElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState(800);
   const reactId = useId();
 
   useEffect(() => {
-    const node = ref.current;
+    const node = containerRef.current;
     if (node === null) {
       return noop;
     }
@@ -68,6 +197,7 @@ export function HairlineChart({
     };
   }, []);
 
+  const plotWidth = Math.max(0, width - PADDING_RIGHT);
   const innerHeight = height - PADDING_TOP - PADDING_BOTTOM;
   const svgStyle = useMemo(() => ({ height }), [height]);
 
@@ -79,23 +209,63 @@ export function HairlineChart({
   }, [values, overlay]);
 
   const linePath = useMemo(
-    () => buildPath(values, width, innerHeight, max),
-    [values, width, innerHeight, max],
+    () => buildPath(values, plotWidth, innerHeight, max),
+    [values, plotWidth, innerHeight, max],
   );
   const areaPath = useMemo(
-    () => buildArea(values, width, innerHeight, max),
-    [values, width, innerHeight, max],
+    () => buildArea(values, plotWidth, innerHeight, max),
+    [values, plotWidth, innerHeight, max],
   );
   const overlayPath = useMemo(
-    () => (overlay ? buildPath(overlay.values, width, innerHeight, max) : null),
-    [overlay, width, innerHeight, max],
+    () => (overlay ? buildPath(overlay.values, plotWidth, innerHeight, max) : null),
+    [overlay, plotWidth, innerHeight, max],
   );
 
-  const handleMove = (e: React.PointerEvent<SVGRectElement>) => {
+  const yearLines = useMemo(
+    () =>
+      from !== undefined && to !== undefined
+        ? yearBoundaries(from, to, values.length, plotWidth)
+        : [],
+    [from, to, values.length, plotWidth],
+  );
+
+  const yearLabels = useMemo(
+    () =>
+      from !== undefined && to !== undefined
+        ? yearMidpointLabels(from, to, values.length, plotWidth)
+        : [],
+    [from, to, values.length, plotWidth],
+  );
+
+  const eventMarks = useMemo(() => {
+    if (from === undefined || values.length === 0) return [];
+    return events
+      .map((e, idx) => {
+        const i = indexFor(e.date, from, values.length);
+        if (i < 0) return null;
+        const x = values.length > 1 ? (i / (values.length - 1)) * plotWidth : 0;
+        const y = yAtIndex(values, i, innerHeight, max);
+        return { ...e, x, y, i, row: idx % 2 };
+      })
+      .filter(
+        (
+          m,
+        ): m is {
+          date: string;
+          label: string;
+          x: number;
+          y: number;
+          i: number;
+          row: number;
+        } => m !== null,
+      );
+  }, [events, from, values, plotWidth, innerHeight, max]);
+
+  const handleMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!onHighlight || values.length === 0) return;
-    const rect = ref.current?.getBoundingClientRect();
+    const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
-    const ratio = (e.clientX - rect.left) / rect.width;
+    const ratio = (e.clientX - rect.left) / Math.max(1, plotWidth);
     const i = Math.max(0, Math.min(values.length - 1, Math.round(ratio * (values.length - 1))));
     onHighlight(i);
   };
@@ -106,75 +276,187 @@ export function HairlineChart({
 
   const highlightX =
     highlightIndex !== undefined && highlightIndex !== null && values.length > 1
-      ? (highlightIndex / (values.length - 1)) * width
+      ? (highlightIndex / (values.length - 1)) * plotWidth
+      : null;
+
+  const primaryEndY =
+    values.length > 0 ? yAtIndex(values, values.length - 1, innerHeight, max) : innerHeight;
+  const overlayEndY =
+    overlay && overlay.values.length > 0
+      ? yAtIndex(overlay.values, overlay.values.length - 1, innerHeight, max)
+      : null;
+
+  const hoverInfo =
+    hoverFormat && highlightIndex !== undefined && highlightIndex !== null
+      ? hoverFormat(highlightIndex)
       : null;
 
   return (
-    <svg
-      ref={ref}
-      role="img"
-      aria-label={ariaLabel}
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      className="block w-full text-ink"
-      style={svgStyle}
-    >
-      <defs>
-        <linearGradient id={`fade-${reactId}`} x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
-          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <g transform={`translate(0, ${PADDING_TOP})`}>
-        {areaPath !== "" && <path d={areaPath} fill={`url(#fade-${reactId})`} stroke="none" />}
-        {overlayPath !== null && (
+    <div ref={containerRef} className="relative w-full" style={svgStyle}>
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className="block w-full text-ink"
+        style={svgStyle}
+      >
+        <defs>
+          <linearGradient id={`fade-${reactId}`} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        <g transform={`translate(0, ${PADDING_TOP})`}>
+          {/* year boundary hairlines */}
+          {yearLines.map((y) => (
+            <line
+              key={`yb-${y.label}`}
+              x1={y.x}
+              x2={y.x}
+              y1={0}
+              y2={innerHeight}
+              stroke="currentColor"
+              strokeWidth={0.5}
+              strokeOpacity={0.18}
+              strokeDasharray="1 3"
+            />
+          ))}
+
+          {/* event hairlines */}
+          {eventMarks.map((e) => (
+            <g key={`ev-${e.date}`}>
+              <line
+                x1={e.x}
+                x2={e.x}
+                y1={e.row === 0 ? -PADDING_TOP + 16 : -PADDING_TOP + 30}
+                y2={e.y}
+                stroke="currentColor"
+                strokeWidth={0.5}
+                strokeOpacity={0.4}
+              />
+            </g>
+          ))}
+
+          {areaPath !== "" && <path d={areaPath} fill={`url(#fade-${reactId})`} stroke="none" />}
+          {overlayPath !== null && (
+            <path
+              d={overlayPath}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={0.85}
+              strokeOpacity={0.45}
+              strokeDasharray="3 2"
+              strokeLinejoin="round"
+            />
+          )}
           <path
-            d={overlayPath}
+            d={linePath}
             fill="none"
             stroke="currentColor"
-            strokeWidth={0.75}
-            strokeOpacity={0.4}
-            strokeDasharray="2 2"
+            strokeWidth={1}
             strokeLinejoin="round"
           />
-        )}
-        <path
-          d={linePath}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={1}
-          strokeLinejoin="round"
-        />
-        {highlightX !== null && (
+
+          {highlightX !== null && (
+            <line
+              x1={highlightX}
+              x2={highlightX}
+              y1={0}
+              y2={innerHeight}
+              stroke="var(--color-accent)"
+              strokeWidth={0.75}
+            />
+          )}
+
+          {/* baseline rule extends across plot only */}
           <line
-            x1={highlightX}
-            x2={highlightX}
-            y1={0}
+            x1={0}
+            x2={plotWidth}
+            y1={innerHeight}
             y2={innerHeight}
-            stroke="var(--color-accent)"
-            strokeWidth={0.75}
+            stroke="currentColor"
+            strokeWidth={0.5}
+            strokeOpacity={0.45}
           />
-        )}
-        <line
-          x1={0}
-          x2={width}
-          y1={innerHeight}
-          y2={innerHeight}
-          stroke="currentColor"
-          strokeWidth={0.5}
-          strokeOpacity={0.45}
+
+          {/* primary curve label at right end */}
+          {primaryLabel !== undefined && values.length > 0 && (
+            <text
+              x={plotWidth + 6}
+              y={primaryEndY}
+              dy="0.32em"
+              fontFamily="var(--font-mono)"
+              fontSize="10"
+              fill="currentColor"
+              opacity={0.85}
+              style={ENDLABEL_STYLE}
+            >
+              {primaryLabel.toUpperCase()}
+            </text>
+          )}
+
+          {/* overlay (compare) label at right end */}
+          {overlay && overlay.label !== undefined && overlayEndY !== null && (
+            <text
+              x={plotWidth + 6}
+              y={overlayEndY}
+              dy="0.32em"
+              fontFamily="var(--font-mono)"
+              fontSize="10"
+              fill="currentColor"
+              opacity={0.55}
+              style={ENDLABEL_STYLE}
+            >
+              {overlay.label.toUpperCase()}
+            </text>
+          )}
+        </g>
+
+        {/* year labels under baseline (midpoint per year) */}
+        <g transform={`translate(0, ${PADDING_TOP + innerHeight + 14})`}>
+          {yearLabels.map((y) => (
+            <text
+              key={`yl-${y.label}`}
+              x={y.x}
+              y={0}
+              fontFamily="var(--font-mono)"
+              fontSize="10"
+              textAnchor="middle"
+              fill="currentColor"
+              opacity={0.55}
+              style={YEARLABEL_STYLE}
+            >
+              {y.label}
+            </text>
+          ))}
+        </g>
+      </svg>
+
+      {/* event annotations (DOM, real typography) — staggered into two rows */}
+      {eventMarks.map((e) => (
+        <EventAnnotation key={`evlabel-${e.date}`} x={e.x} row={e.row} label={e.label} />
+      ))}
+
+      {/* hover annotation, floating next to the scrub line */}
+      {highlightX !== null && hoverInfo !== null && (
+        <HoverAnnotation
+          left={Math.min(highlightX + ANNOTATION_OFFSET, plotWidth - 160)}
+          top={PADDING_TOP - 14}
+          date={hoverInfo.date}
+          primary={hoverInfo.primary}
+          compare={hoverInfo.compare ?? null}
         />
-      </g>
-      <rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill="transparent"
+      )}
+
+      {/* pointer capture overlay */}
+      <div
+        className="absolute inset-0"
         onPointerMove={handleMove}
         onPointerLeave={handleLeave}
         style={onHighlight ? CURSOR_CROSSHAIR_STYLE : CURSOR_DEFAULT_STYLE}
       />
-    </svg>
+    </div>
   );
 }

--- a/web/src/components/inline-picker.tsx
+++ b/web/src/components/inline-picker.tsx
@@ -1,0 +1,66 @@
+import {
+  Button as AriaButton,
+  Popover as AriaPopover,
+  Dialog as AriaDialog,
+  DialogTrigger,
+} from "react-aria-components";
+import type { ReactNode } from "react";
+import cs from "clsx";
+
+interface InlinePickerProps {
+  label: string;
+  className?: string;
+  children: (close: () => void) => ReactNode;
+}
+
+const triggerBase = cs([
+  "font-display italic",
+  "border-b border-dotted border-rule",
+  "transition-colors",
+  "outline-none cursor-pointer",
+  "text-ink hover:text-accent hover:border-accent",
+  "focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent focus-visible:outline-offset-2",
+]);
+
+const popoverStyle = cs([
+  "min-w-[14rem] max-w-[24rem] max-h-72 overflow-auto",
+  "bg-paper border border-ink-faint",
+  "shadow-[0_8px_24px_-12px_rgba(26,22,18,0.18)]",
+  "rounded-none",
+  "px-3 py-3",
+]);
+
+export function InlinePicker({ label, className, children }: InlinePickerProps) {
+  return (
+    <DialogTrigger>
+      <AriaButton className={cs(triggerBase, className)}>{label}</AriaButton>
+      <AriaPopover className={popoverStyle} placement="bottom start" offset={8}>
+        <AriaDialog className="outline-none">{({ close }) => children(close)}</AriaDialog>
+      </AriaPopover>
+    </DialogTrigger>
+  );
+}
+
+interface PickerListItemProps {
+  selected: boolean;
+  onPress: () => void;
+  children: ReactNode;
+}
+
+export function PickerListItem({ selected, onPress, children }: PickerListItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onPress}
+      className={cs(
+        "block w-full text-left px-2 py-1 transition-colors cursor-pointer outline-none",
+        "font-body text-sm",
+        selected
+          ? "text-accent border-l-2 border-accent pl-1.5"
+          : "text-ink-quiet hover:text-ink hover:bg-paper-deep border-l-2 border-transparent",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/src/components/pages/pandemic.tsx
+++ b/web/src/components/pages/pandemic.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useAtom } from "jotai";
 import { DateTime } from "luxon";
 import type { PandemicDataset, PandemicMetric } from "@kronos/common";
@@ -8,65 +8,232 @@ import { Loading } from "../base/loading";
 import { FolioMark, RunningHead } from "../page-frame";
 import { Imprint } from "../imprint";
 import { QueryErrorBoundary } from "../../query/query-provider";
-import { Switch } from "../base/Switch";
-import { PandemicStateSelector } from "../pandemic-state-selector";
+import { InlinePicker, PickerListItem } from "../inline-picker";
 import { HairlineChart } from "../hairline-chart";
 import { addDays, dayDiff, pickYears, sliceSeries } from "../../lib/pandemic-slice";
 
 const FOLIO = "06";
 const HERO_STYLE = { fontSize: "clamp(4rem,15vw,9rem)" } as const;
+const METRIC_STYLE = { fontSize: "clamp(1.75rem,4.5vw,2.5rem)" } as const;
 const CASES_THRESHOLD = 1000;
 const DEATHS_THRESHOLD = 10;
+const CHART_HEIGHT = 320;
 
-function metricLabel(metric: PandemicMetric): string {
-  return metric === "cases" ? "cases" : "deaths";
-}
+const NAMED_EVENTS: { date: string; label: string }[] = [
+  { date: "2020-03-18", label: "MCO begins" },
+  { date: "2021-02-24", label: "vaccine rollout" },
+  { date: "2021-08-26", label: "delta peak" },
+  { date: "2022-04-01", label: "endemic transition" },
+];
 
 function fmtInt(n: number): string {
   return new Intl.NumberFormat("en-US").format(Math.round(n));
 }
 
 function fmtDate(iso: string, opts?: Intl.DateTimeFormatOptions): string {
-  const dt = DateTime.fromISO(iso);
-  return dt.toLocaleString(opts ?? { day: "numeric", month: "long", year: "numeric" });
+  return DateTime.fromISO(iso).toLocaleString(
+    opts ?? { day: "numeric", month: "long", year: "numeric" },
+  );
 }
 
-interface YearTabsProps {
+function fmtMonthYearShort(iso: string): string {
+  return DateTime.fromISO(iso).toLocaleString({ day: "numeric", month: "short", year: "numeric" });
+}
+
+interface ChapterMarkProps {
+  numeral: string;
+  title: string;
+}
+
+function ChapterMark({ numeral, title }: ChapterMarkProps) {
+  return (
+    <div className="flex items-baseline gap-3 pb-2 border-b border-rule">
+      <span className="font-display italic text-2xl text-accent leading-none">{numeral}</span>
+      <span className="kicker text-ink-quiet text-sm">— {title}</span>
+    </div>
+  );
+}
+
+interface MetricToggleProps {
+  value: PandemicMetric;
+  onChange: (next: PandemicMetric) => void;
+}
+
+function MetricToggle({ value, onChange }: MetricToggleProps) {
+  return (
+    <div className="flex items-baseline gap-6 select-none">
+      <button
+        type="button"
+        onClick={() => {
+          onChange("cases");
+        }}
+        className={
+          value === "cases"
+            ? "font-display italic text-ink border-b-2 border-accent pb-1 transition-colors cursor-pointer"
+            : "font-display italic text-ink-quiet hover:text-accent transition-colors cursor-pointer"
+        }
+        style={METRIC_STYLE}
+      >
+        cases
+      </button>
+      <span aria-hidden="true" className="text-ink-faint text-2xl">
+        ·
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          onChange("deaths");
+        }}
+        className={
+          value === "deaths"
+            ? "font-display italic text-ink border-b-2 border-accent pb-1 transition-colors cursor-pointer"
+            : "font-display italic text-ink-quiet hover:text-accent transition-colors cursor-pointer"
+        }
+        style={METRIC_STYLE}
+      >
+        deaths
+      </button>
+    </div>
+  );
+}
+
+interface YearPickerProps {
   available: string[];
   value: string;
-  onChange: (year: string) => void;
+  onChange: (next: string) => void;
+  label: string;
 }
 
-function YearTabs({ available, value, onChange }: YearTabsProps) {
+function YearPicker({ available, value, onChange, label }: YearPickerProps) {
   const all: { key: string; label: string }[] = [
-    { key: "all", label: "all" },
+    { key: "all", label: "all years" },
     ...available.map((y) => ({ key: y, label: y })),
   ];
   return (
-    <div className="flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 kicker">
-      {all.map((t, i) => (
-        <span key={t.key} className="inline-flex items-baseline gap-3">
-          {i > 0 && (
-            <span aria-hidden="true" className="text-ink-faint">
-              ·
-            </span>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              onChange(t.key);
-            }}
-            className={
-              t.key === value
-                ? "text-accent border-b border-accent pb-px transition-colors cursor-pointer"
-                : "text-ink-mute hover:text-accent transition-colors cursor-pointer"
-            }
-          >
-            {t.label}
-          </button>
-        </span>
-      ))}
-    </div>
+    <InlinePicker label={label}>
+      {(close) => (
+        <div className="flex flex-col">
+          <div className="kicker text-ink-mute mb-2">Year</div>
+          {all.map((t) => (
+            <PickerListItem
+              key={t.key}
+              selected={t.key === value}
+              onPress={() => {
+                onChange(t.key);
+                close();
+              }}
+            >
+              {t.label}
+            </PickerListItem>
+          ))}
+        </div>
+      )}
+    </InlinePicker>
+  );
+}
+
+interface StatePickerProps {
+  states: string[];
+  value: string;
+  onChange: (next: string) => void;
+}
+
+function StatePicker({ states, value, onChange }: StatePickerProps) {
+  return (
+    <InlinePicker label={value}>
+      {(close) => (
+        <div className="flex flex-col">
+          <div className="kicker text-ink-mute mb-2">State</div>
+          {states.map((s) => (
+            <PickerListItem
+              key={s}
+              selected={s === value}
+              onPress={() => {
+                onChange(s);
+                close();
+              }}
+            >
+              {s}
+            </PickerListItem>
+          ))}
+        </div>
+      )}
+    </InlinePicker>
+  );
+}
+
+interface CompareSlotProps {
+  states: string[];
+  value: string | null;
+  onChange: (next: string | null) => void;
+}
+
+function CompareSlot({ states, value, onChange }: CompareSlotProps) {
+  if (value === null) {
+    return (
+      <InlinePicker label="+ alongside another state">
+        {(close) => (
+          <div className="flex flex-col">
+            <div className="kicker text-ink-mute mb-2">Compare with</div>
+            {states.map((s) => (
+              <PickerListItem
+                key={s}
+                selected={false}
+                onPress={() => {
+                  onChange(s);
+                  close();
+                }}
+              >
+                {s}
+              </PickerListItem>
+            ))}
+          </div>
+        )}
+      </InlinePicker>
+    );
+  }
+  return (
+    <span className="font-display italic text-ink-quiet inline-flex items-baseline gap-2">
+      <span>alongside</span>
+      <InlinePicker label={value}>
+        {(close) => (
+          <div className="flex flex-col">
+            <div className="kicker text-ink-mute mb-2">Compare with</div>
+            <PickerListItem
+              selected={false}
+              onPress={() => {
+                onChange(null);
+                close();
+              }}
+            >
+              (none)
+            </PickerListItem>
+            {states.map((s) => (
+              <PickerListItem
+                key={s}
+                selected={s === value}
+                onPress={() => {
+                  onChange(s);
+                  close();
+                }}
+              >
+                {s}
+              </PickerListItem>
+            ))}
+          </div>
+        )}
+      </InlinePicker>
+      <button
+        type="button"
+        onClick={() => {
+          onChange(null);
+        }}
+        className="kicker text-ink-faint hover:text-accent transition-colors cursor-pointer"
+        aria-label="Clear comparison"
+      >
+        ×
+      </button>
+    </span>
   );
 }
 
@@ -79,6 +246,7 @@ function OnThisDay({ dataset, state }: OnThisDayProps) {
   const minDate =
     dataset.cases.from < dataset.deaths.from ? dataset.cases.from : dataset.deaths.from;
   const maxDate = dataset.cases.to > dataset.deaths.to ? dataset.cases.to : dataset.deaths.to;
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const [date, setDate] = useState<string>("2021-08-26");
 
@@ -100,23 +268,41 @@ function OnThisDay({ dataset, state }: OnThisDayProps) {
       ? (deathsValues[deathsIdx] ?? 0)
       : null;
 
+  const openPicker = () => {
+    const el = inputRef.current;
+    if (el && typeof el.showPicker === "function") {
+      el.showPicker();
+    } else {
+      el?.focus();
+    }
+  };
+
   return (
-    <section className="flex flex-col gap-5 pt-4">
-      <div className="flex items-baseline gap-3">
-        <span className="kicker text-ink-mute">On this day</span>
-        <span className="flex-1 border-t border-dotted border-rule translate-y-[-0.3rem]" />
-        <span className="marginalia">{state}</span>
+    <section className="flex flex-col gap-6">
+      <div className="font-display italic text-ink-quiet text-base sm:text-lg max-w-[44ch]">
+        Where the country stood on a particular day, set against the rest of the record.
       </div>
-      <input
-        type="date"
-        value={date}
-        min={minDate}
-        max={maxDate}
-        onChange={(e) => {
-          setDate(e.target.value);
-        }}
-        className="bg-transparent border-0 border-b border-rule focus:border-accent focus:border-b-2 outline-none font-display italic text-lg text-ink py-2 px-0 transition-colors w-full max-w-xs"
-      />
+      <div className="relative inline-flex items-baseline gap-3 max-w-xs">
+        <input
+          ref={inputRef}
+          type="date"
+          value={date}
+          min={minDate}
+          max={maxDate}
+          onChange={(e) => {
+            setDate(e.target.value);
+          }}
+          className="kronos-bare-date bg-transparent border-0 border-b border-rule focus:border-accent focus:border-b-2 outline-none font-display italic text-lg text-ink py-2 px-0 transition-colors flex-1"
+        />
+        <button
+          type="button"
+          onClick={openPicker}
+          className="text-ink-mute hover:text-accent transition-colors cursor-pointer"
+          aria-label="Open date picker"
+        >
+          <span aria-hidden="true" className="icon-[lucide--calendar] text-base" />
+        </button>
+      </div>
       {!valid && (
         <div className="font-display italic text-ink-quiet">
           The record does not extend to that day.
@@ -131,8 +317,7 @@ function OnThisDay({ dataset, state }: OnThisDayProps) {
             </span>
             {!inCasesRange && (
               <span className="marginalia mt-1">
-                cases record ended{" "}
-                {fmtDate(dataset.cases.to, { day: "numeric", month: "short", year: "numeric" })}
+                cases record ended {fmtMonthYearShort(dataset.cases.to)}
               </span>
             )}
           </div>
@@ -143,8 +328,7 @@ function OnThisDay({ dataset, state }: OnThisDayProps) {
             </span>
             {!inDeathsRange && (
               <span className="marginalia mt-1">
-                deaths record ended{" "}
-                {fmtDate(dataset.deaths.to, { day: "numeric", month: "short", year: "numeric" })}
+                deaths record ended {fmtMonthYearShort(dataset.deaths.to)}
               </span>
             )}
           </div>
@@ -187,10 +371,36 @@ function PageContent() {
   );
   const overlayProp = useMemo(
     () =>
-      compareSlice === null
-        ? null
-        : { values: compareSlice.values, ariaLabel: effectiveCompare ?? "" },
+      compareSlice === null ? null : { values: compareSlice.values, label: effectiveCompare ?? "" },
     [compareSlice, effectiveCompare],
+  );
+  const visibleEvents = useMemo(
+    () =>
+      slice === null ? [] : NAMED_EVENTS.filter((e) => e.date >= slice.from && e.date <= slice.to),
+    [slice],
+  );
+  const formatHover = useCallback(
+    (i: number) => {
+      if (slice === null) return { date: "", primary: "", compare: null };
+      const date = fmtDate(addDays(slice.from, i), {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      });
+      const v = slice.values[i] ?? 0;
+      const primary = `${fmtInt(v)} ${state}`;
+      const compareV =
+        compareSlice && i < compareSlice.values.length ? (compareSlice.values[i] ?? 0) : null;
+      return {
+        date,
+        primary,
+        compare:
+          compareV !== null && effectiveCompare !== null
+            ? `${fmtInt(compareV)} ${effectiveCompare}`
+            : null,
+      };
+    },
+    [slice, state, compareSlice, effectiveCompare],
   );
 
   if (isLoading || !dataset || !slice || !series) {
@@ -204,24 +414,17 @@ function PageContent() {
     );
   }
 
-  const period =
+  const periodLabel =
     effectiveYear === "all"
-      ? `${fmtDate(slice.from, { year: "numeric" })}–${fmtDate(slice.to, { year: "numeric" })}`
+      ? `${DateTime.fromISO(slice.from).year}–${DateTime.fromISO(slice.to).year}`
       : effectiveYear;
 
-  const highlightDate = highlight === null ? null : addDays(slice.from, highlight);
-  const highlightValue =
-    highlight === null || highlight >= slice.values.length ? null : (slice.values[highlight] ?? 0);
-  const highlightCompare =
-    compareSlice === null || highlight === null || highlight >= compareSlice.values.length
-      ? null
-      : (compareSlice.values[highlight] ?? 0);
-  const compareLabel = effectiveCompare;
-
-  const dailyAvg = slice.mean;
+  const peakOrdinal = slice.peak
+    ? fmtDate(slice.peak.date, { day: "numeric", month: "long", year: "numeric" })
+    : "—";
 
   return (
-    <div className="reveal-stack mx-auto w-full max-w-3xl flex flex-col gap-12">
+    <div className="reveal-stack mx-auto w-full max-w-3xl flex flex-col gap-14">
       <RunningHead section="Pandemic" folio={FOLIO} />
       <Imprint setAt={dataUpdatedAt} />
 
@@ -232,137 +435,120 @@ function PageContent() {
         </div>
       </header>
 
-      <div className="flex justify-center">
-        <Switch
-          isSelected={metric === "deaths"}
-          onChange={(b) => {
-            setMetric(b ? "deaths" : "cases");
-          }}
-          offLabel="cases"
-          onLabel="deaths"
-        >
-          Reading
-        </Switch>
-      </div>
+      {/* I — At a glance */}
+      <section className="flex flex-col gap-8">
+        <ChapterMark numeral="I" title="At a glance" />
 
-      <section className="flex flex-col items-center text-center gap-4">
-        <div className="kicker text-accent">
-          <span className="text-ink-faint">·</span> {state}{" "}
-          <span className="text-ink-faint">·</span> {period}{" "}
-          <span className="text-ink-faint">·</span>
+        <div className="flex flex-col gap-7">
+          <p className="font-display italic text-lg sm:text-xl text-ink-quiet leading-snug">
+            Across{" "}
+            <YearPicker
+              available={years}
+              value={effectiveYear}
+              onChange={(y) => void setYear(y)}
+              label={periodLabel}
+            />
+            ,{" "}
+            <StatePicker states={dataset.states} value={state} onChange={(s) => void setState(s)} />{" "}
+            recorded
+          </p>
+
+          <div
+            className="font-display italic text-ink tabular leading-[0.92] tracking-tight text-center"
+            style={HERO_STYLE}
+          >
+            {fmtInt(slice.total)}
+          </div>
+
+          <div className="flex flex-col items-center gap-3">
+            <MetricToggle value={metric} onChange={setMetric} />
+            <p className="font-display italic text-ink-quiet text-base sm:text-lg leading-snug">
+              <CompareSlot
+                states={otherStates}
+                value={effectiveCompare}
+                onChange={(s) => void setCompare(s)}
+              />
+            </p>
+          </div>
         </div>
-        <div
-          className="font-display italic text-ink tabular leading-[0.92] tracking-tight"
-          style={HERO_STYLE}
-        >
-          {fmtInt(slice.total)}
-        </div>
-        <div className="font-display italic text-base sm:text-lg text-ink-quiet max-w-[44ch]">
-          {metricLabel(metric)} recorded across the period.
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 border-t border-b border-rule-soft py-6">
+          <div className="flex flex-col gap-1">
+            <span className="kicker text-ink-mute">Peak day</span>
+            {slice.peak ? (
+              <>
+                <span className="font-display italic text-xl text-ink">{peakOrdinal}</span>
+                <span className="font-mono tabular text-xs text-ink-quiet">
+                  {fmtInt(slice.peak.value)} {metric}
+                </span>
+              </>
+            ) : (
+              <span className="font-display italic text-ink-quiet">—</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="kicker text-ink-mute">Daily mean</span>
+            <span className="font-display italic text-xl text-ink tabular">
+              {fmtInt(slice.mean)}
+            </span>
+            <span className="font-mono tabular text-xs text-ink-quiet">
+              across {slice.values.length} days
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="kicker text-ink-mute">
+              {metric === "cases" ? "Days exceeding a thousand" : "Days exceeding ten"}
+            </span>
+            <span className="font-display italic text-xl text-ink tabular">
+              {fmtInt(slice.daysOverThreshold)}
+            </span>
+            <span className="font-mono tabular text-xs text-ink-quiet">
+              of {slice.values.length}
+            </span>
+          </div>
         </div>
       </section>
 
-      <section className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 border-t border-b border-rule-soft py-6">
-        <div className="flex flex-col gap-1">
-          <span className="kicker text-ink-mute">Peak day</span>
-          {slice.peak ? (
-            <>
-              <span className="font-display italic text-xl text-ink">
-                {fmtDate(slice.peak.date, { day: "numeric", month: "short", year: "2-digit" })}
-              </span>
-              <span className="font-mono tabular text-xs text-ink-quiet">
-                {fmtInt(slice.peak.value)} {metricLabel(metric)}
-              </span>
-            </>
-          ) : (
-            <span className="font-display italic text-ink-quiet">—</span>
-          )}
-        </div>
-        <div className="flex flex-col gap-1">
-          <span className="kicker text-ink-mute">Daily mean</span>
-          <span className="font-display italic text-xl text-ink tabular">{fmtInt(dailyAvg)}</span>
-          <span className="font-mono tabular text-xs text-ink-quiet">
-            across {slice.values.length} days
-          </span>
-        </div>
-        <div className="flex flex-col gap-1">
-          <span className="kicker text-ink-mute">Days ≥ {metric === "cases" ? "1,000" : "10"}</span>
-          <span className="font-display italic text-xl text-ink tabular">
-            {fmtInt(slice.daysOverThreshold)}
-          </span>
-          <span className="font-mono tabular text-xs text-ink-quiet">of {slice.values.length}</span>
-        </div>
-      </section>
-
-      <section className="flex flex-col gap-3">
+      {/* II — The curve */}
+      <section className="flex flex-col gap-5">
+        <ChapterMark numeral="II" title="The curve" />
         <div className="flex items-baseline gap-3">
-          <span className="kicker text-ink-mute">Curve</span>
+          <span className="font-display italic text-ink-quiet text-base">
+            Daily {metric}, drawn at hairline weight.
+          </span>
           <span className="flex-1 border-t border-dotted border-rule translate-y-[-0.3rem]" />
           <span className="marginalia">
-            {fmtDate(slice.from, { day: "numeric", month: "short", year: "2-digit" })} —{" "}
-            {fmtDate(slice.to, { day: "numeric", month: "short", year: "2-digit" })}
+            {fmtMonthYearShort(slice.from)} — {fmtMonthYearShort(slice.to)}
           </span>
         </div>
         <HairlineChart
           values={slice.values}
+          height={CHART_HEIGHT}
           highlightIndex={highlight}
           onHighlight={setHighlight}
-          ariaLabel={`Daily ${metric} for ${state}, ${period}`}
+          ariaLabel={`Daily ${metric} for ${state}, ${periodLabel}`}
+          from={slice.from}
+          to={slice.to}
+          events={visibleEvents}
+          primaryLabel={state}
           overlay={overlayProp}
+          hoverFormat={formatHover}
         />
-        <div className="flex items-baseline justify-between min-h-[1.5rem]">
-          <span className="font-mono tabular text-xs text-ink-mute">
-            {highlightDate === null
-              ? ""
-              : fmtDate(highlightDate, { day: "numeric", month: "long", year: "numeric" })}
-          </span>
-          <span className="font-mono tabular text-xs text-ink">
-            {highlightValue === null ? "" : `${fmtInt(highlightValue)} ${state}`}
-            {highlightCompare !== null && compareLabel !== null ? (
-              <span className="text-ink-mute">
-                {" · "}
-                {fmtInt(highlightCompare)} {compareLabel}
-              </span>
-            ) : null}
-          </span>
-        </div>
       </section>
 
+      {/* III — On a particular day */}
       <section className="flex flex-col gap-6">
-        <div className="flex items-baseline gap-3">
-          <span className="kicker text-ink-mute">Set the reading</span>
-          <span className="flex-1 border-t border-rule" />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <span className="kicker text-ink-mute">Year</span>
-          <YearTabs available={years} value={effectiveYear} onChange={(y) => void setYear(y)} />
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <PandemicStateSelector
-            label="State"
-            value={state}
-            onChange={(s) => void setState(s ?? "Malaysia")}
-            states={dataset.states}
-          />
-          <PandemicStateSelector
-            label="Compare with"
-            value={compare}
-            onChange={(s) => void setCompare(s)}
-            states={otherStates}
-            placeholder="(none)"
-            allowClear
-          />
-        </div>
+        <ChapterMark numeral="III" title="On a particular day" />
+        <OnThisDay dataset={dataset} state={state} />
       </section>
 
-      <OnThisDay dataset={dataset} state={state} />
-
-      <section className="border-t border-rule-soft pt-6 flex flex-col gap-2">
+      <section className="border-t border-rule-soft pt-8 flex flex-col gap-2">
         <span className="kicker text-ink-mute">Source</span>
         <p className="font-display italic text-sm text-ink-quiet leading-relaxed max-w-[58ch]">
-          MoH Malaysia, via{" "}
+          <span className="float-left font-display not-italic font-normal text-[2.5rem] leading-[0.78] text-accent mr-2 mt-[0.2rem] select-none">
+            M
+          </span>
+          oH Malaysia, via{" "}
           <a
             href="https://data.gov.my"
             className="text-accent hover:underline"

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -201,3 +201,11 @@
     animation: none;
   }
 }
+
+input.kronos-bare-date::-webkit-calendar-picker-indicator {
+  display: none;
+}
+input.kronos-bare-date::-webkit-inner-spin-button,
+input.kronos-bare-date::-webkit-clear-button {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Restructures `/pandemic` into three numbered chapters (I — At a glance, II — The curve, III — On a particular day). The page now reads as a record, not a control panel.
- Hero is a flowing italic sentence — *"Across [period], [state] recorded"* — with year and state as inline pickers (popover lists). Compare appears inline as an *"alongside [state]"* rider with × to clear; opt-in only.
- Metric toggle (cases · deaths) is headline-scale type set against the hero numeral, not a buried form switch.
- Curve grew from 180 → 320 px with year-boundary hairlines, mono year labels at midpoints, and four named events (MCO begins, vaccine rollout, delta peak, endemic transition) staggered into two rows. Hover annotation moves inside the chart container as a floating overlay near the scrub line. Each curve is labelled in mono at the right end so primary vs comparison is unambiguous.
- On a particular day suppresses the native date picker chrome and adds a lucide-calendar trigger that calls `showPicker()`.
- Source paragraph picks up a drop cap on the M of MoH in PP Editorial New roman, oxblood — the editorial signature CLAUDE.md specifies.
- Threshold-stat copy: *"Days ≥ 1,000"* → *"Days exceeding a thousand"* (and *"Days exceeding ten"* on the deaths side).

## Test plan
- [x] typecheck / lint / test / format:check / build all green
- [x] Light + dark mode visual check
- [x] Hover scrub: inline date + value annotation appears next to the cursor; clears on leave
- [x] Year picker: italic word in headline opens popover; selection updates hero, stats, curve
- [x] State picker: same flow
- [x] Compare slot: starts as "+ alongside another state"; once set, renders as "alongside [state] ×"
- [x] Metric toggle: cases ↔ deaths switches the hero numeral, stats threshold copy, and curve
- [x] On this day: native calendar indicator hidden; lucide button opens picker; out-of-range copy ("deaths record ended …") appears past 18 May 2024
- [x] Curve: year boundary hairlines visible, year labels span 20–25, four event annotations staggered into two rows without collision, MALAYSIA / SELANGOR labels at right end of each curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)